### PR TITLE
fix for GsdkConfig

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,8 @@ jobs:
           go-version: 1.16.5
       - name: build Docker images
         run: make builddockerlocal
+      - name: initcontainer unit tests
+        run: cd initcontainer && go test
       - name: sidecar unit tests
         run: cd sidecar-go && go test
       - name: operator unit tests

--- a/initcontainer/go.mod
+++ b/initcontainer/go.mod
@@ -3,6 +3,6 @@ module github.com/playfab/thundernetes/initcontainer
 go 1.16
 
 require (
-	github.com/pkg/errors v0.9.1 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.8.1
 )

--- a/initcontainer/go.mod
+++ b/initcontainer/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.2.2
 )

--- a/initcontainer/go.sum
+++ b/initcontainer/go.sum
@@ -1,9 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/initcontainer/main.go
+++ b/initcontainer/main.go
@@ -21,7 +21,7 @@ type GsdkConfig struct {
 	CertificateFolder        string                   `json:"certificateFolder"`
 	SharedContentFolder      string                   `json:"sharedContentFolder"`
 	BuildMetadata            map[string]string        `json:"buildMetadata"`
-	GamePorts                map[string]int           `json:"gamePorts"`
+	GamePorts                map[string]string        `json:"gamePorts"`
 	PublicIpV4Address        string                   `json:"publicIpV4Address"`
 	GameServerConnectionInfo GameServerConnectionInfo `json:"gameServerConnectionInfo"`
 	ServerInstanceNumber     int                      `json:"serverInstanceNumber"` // Not used
@@ -116,12 +116,12 @@ func parseBuildMetadata() map[string]string {
 	return buildMetadata
 }
 
-func parsePorts() (map[string]int, []GamePort, error) {
+func parsePorts() (map[string]string, []GamePort, error) {
 	// format is port.Name + "," + containerPort + "," + hostPort + "?" + ...
 	// similar to how docker run -p works https://docs.docker.com/config/containers/container-networking/
 	s := strings.Split(gamePortsString, "?")
 	gamePortConfiguration := make([]GamePort, 0)
-	gamePorts := make(map[string]int)
+	gamePorts := make(map[string]string)
 	for _, s2 := range s {
 		if s2 == "" {
 			continue
@@ -141,7 +141,7 @@ func parsePorts() (map[string]int, []GamePort, error) {
 			ServerListeningPort:  containerPort,
 			ClientConnectionPort: hostPort,
 		})
-		gamePorts[s3[0]] = containerPort
+		gamePorts[s3[0]] = strconv.Itoa(containerPort)
 	}
 	return gamePorts, gamePortConfiguration, nil
 }

--- a/initcontainer/main_test.go
+++ b/initcontainer/main_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testGsdkConfigFile      = "/tmp/GsdkConfig.json"
+	testHeartbeatEndpoint   = "http://localhost:8080/heartbeat"
+	testSharedContentFolder = "testSharedContentFolder"
+	testCertificateFolder   = "testCertificateFolder"
+	testLogDirectory        = "testLogDirectory"
+	testVmId                = "testVmId"
+	testGameServerName      = "testGameServerName"
+	testGameServerNamespace = "testGameServerNamespace"
+	testGameServerPorts     = "portName,80,10000?portName2,443,10001"
+	testBuildMetadata       = "key1,value1?key2,value2"
+)
+
+type initContainerTestSuite struct {
+	suite.Suite
+}
+
+func (suite *initContainerTestSuite) SetupSuite() {
+	log.Println("Setting env variables")
+	setEnvVariables()
+}
+
+func (suite *initContainerTestSuite) TearDownSuite() {
+	log.Println("Unsetting env variables")
+	unsetEnvVariables()
+	err := os.Remove(testGsdkConfigFile)
+	assert.NoError(suite.T(), err)
+}
+
+// TestInitContainer tests the core functionality of the init container
+// which is to create a proper GSDK file
+func (suite *initContainerTestSuite) TestInitContainer() {
+	main()
+	assert.FileExists(suite.T(), testGsdkConfigFile)
+	jsonFile, err := os.Open(testGsdkConfigFile)
+	assert.NoError(suite.T(), err)
+	defer jsonFile.Close()
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	assert.NoError(suite.T(), err)
+	var gsdkConfig *GsdkConfig
+	err = json.Unmarshal(byteValue, &gsdkConfig)
+	assert.NoError(suite.T(), err)
+
+	assert.Equal(suite.T(), testHeartbeatEndpoint, gsdkConfig.HeartbeatEndpoint)
+	assert.Equal(suite.T(), testSharedContentFolder, gsdkConfig.SharedContentFolder)
+	assert.Equal(suite.T(), testCertificateFolder, gsdkConfig.CertificateFolder)
+	assert.Equal(suite.T(), testLogDirectory, gsdkConfig.LogFolder)
+	assert.Equal(suite.T(), testVmId, gsdkConfig.VmId)
+	assert.Equal(suite.T(), testGameServerName, gsdkConfig.SessionHostId)
+
+	portsMap, ports, err := parsePorts()
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), portsMap, map[string]string{"portName": "80", "portName2": "443"})
+	assert.Equal(suite.T(), ports, []GamePort{{Name: "portName", ServerListeningPort: 80, ClientConnectionPort: 10000}, {Name: "portName2", ServerListeningPort: 443, ClientConnectionPort: 10001}})
+
+	metadata := parseBuildMetadata()
+	assert.Equal(suite.T(), metadata, map[string]string{"key1": "value1", "key2": "value2"})
+}
+
+// TestInitContainerSuite launches the test suite
+func TestInitContainerSuite(t *testing.T) {
+	suite.Run(t, new(initContainerTestSuite))
+}
+
+func setEnvVariables() {
+	os.Setenv("GSDK_CONFIG_FILE", testGsdkConfigFile)
+	os.Setenv("HEARTBEAT_ENDPOINT", testHeartbeatEndpoint)
+	os.Setenv("PF_SHARED_CONTENT_FOLDER", testSharedContentFolder)
+	os.Setenv("CERTIFICATE_FOLDER", testCertificateFolder)
+	os.Setenv("PF_SERVER_LOG_DIRECTORY", testLogDirectory)
+	os.Setenv("PF_VM_ID", testVmId)
+	os.Setenv("PF_GAMESERVER_NAME", testGameServerName)
+	os.Setenv("PF_GAMESERVER_NAMESPACE", testGameServerNamespace)
+	os.Setenv("PF_GAMESERVER_PORTS", testGameServerPorts)
+	os.Setenv("PF_GAMESERVER_BUILD_METADATA", testBuildMetadata)
+}
+
+func unsetEnvVariables() {
+	os.Unsetenv("GSDK_CONFIG_FILE")
+	os.Unsetenv("HEARTBEAT_ENDPOINT")
+	os.Unsetenv("PF_SHARED_CONTENT_FOLDER")
+	os.Unsetenv("CERTIFICATE_FOLDER")
+	os.Unsetenv("PF_SERVER_LOG_DIRECTORY")
+	os.Unsetenv("PF_VM_ID")
+	os.Unsetenv("PF_GAMESERVER_NAME")
+	os.Unsetenv("PF_GAMESERVER_NAMESPACE")
+	os.Unsetenv("PF_GAMESERVER_PORTS")
+	os.Unsetenv("PF_GAMESERVER_BUILD_METADATA")
+}


### PR DESCRIPTION
While [creating the Go GSDK](https://github.com/PlayFab/gsdk/pull/103) and testing with the [LocalMultiplayerAgent](https://github.com/PlayFab/MpsAgent), we found out that the GsdkConfig.GamePorts field should actually be map[string]string instead of map[string]int. We verified it by checking some MPS VMs as well. As we copied this type on the Go GSDK from the one here in the thundernetes repo, we should make that change here as well. Created #57 to create unit tests for initcontainer as well.