### PR TITLE
renaming CRD instance to CR

### DIFF
--- a/operator/controllers/gameserverbuild_controller_test.go
+++ b/operator/controllers/gameserverbuild_controller_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GameServerBuild controller tests", func() {
 
 		// tests here follow the flow
 		// 1. create a gameserverbuild
-		// 2. verify that we have the requested count of GameServer CRD instances
+		// 2. verify that we have the requested count of GameServer CRs
 		// 3. since we don't have containers running (so the sidecar can update the GameServer.Status), we manually
 		//    set the initializing GameServers' .Status to standingBy
 		// 4. verify the number of standingBy and active GameServers

--- a/sidecar-go/httphandler.go
+++ b/sidecar-go/httphandler.go
@@ -108,7 +108,7 @@ func (h *httpHandler) gameServerUpdated(oldObj, newObj interface{}) {
 		return
 	}
 
-	h.logger.Infof("GameServer CRD instance updated %s:%s,%s,%s", old.GetName(), oldState, new.GetName(), newState)
+	h.logger.Infof("GameServer CR updated %s:%s,%s,%s", old.GetName(), oldState, new.GetName(), newState)
 
 	// if the GameServer was allocated
 	if oldState == string(GameStateStandingBy) && newState == string(GameStateActive) {


### PR DESCRIPTION
Renaming the phrase "CRD instance" to the more accurate  and simpler "CR"