### PR TITLE
adding node internal ip + node name

### DIFF
--- a/initcontainer/main.go
+++ b/initcontainer/main.go
@@ -49,6 +49,7 @@ var (
 	gamePortsString         string
 	sessionHostId           string
 	crdNamespace            string
+	nodeInternalIP          string
 	logger                  *log.Entry
 )
 
@@ -74,9 +75,9 @@ func main() {
 		SharedContentFolder: sharedContentFolderPath,
 		BuildMetadata:       buildMetadata,
 		GamePorts:           gamePorts,
-		PublicIpV4Address:   "N/A", // TODO: can we have that here?
+		PublicIpV4Address:   nodeInternalIP, // this is the internal IP of the node
 		GameServerConnectionInfo: GameServerConnectionInfo{
-			PublicIpV4Address:      "N/A",
+			PublicIpV4Address:      nodeInternalIP,
 			GamePortsConfiguration: gamePortConfiguration,
 		},
 		FullyQualifiedDomainName: "NOT_APPLICABLE",
@@ -195,4 +196,7 @@ func getRestEnvVariables() {
 
 	gamePortsString = os.Getenv("PF_GAMESERVER_PORTS")
 	checkEnvOrFatal("PF_GAMESERVER_PORTS", gamePortsString)
+
+	nodeInternalIP = os.Getenv("PF_NODE_INTERNAL_IP")
+	checkEnvOrFatal("PF_NODE_INTERNAL_IP", nodeInternalIP)
 }

--- a/initcontainer/main_test.go
+++ b/initcontainer/main_test.go
@@ -22,6 +22,7 @@ const (
 	testGameServerNamespace = "testGameServerNamespace"
 	testGameServerPorts     = "portName,80,10000?portName2,443,10001"
 	testBuildMetadata       = "key1,value1?key2,value2"
+	testNodeInternalIP      = "127.0.0.1"
 )
 
 type initContainerTestSuite struct {
@@ -60,6 +61,8 @@ func (suite *initContainerTestSuite) TestInitContainer() {
 	assert.Equal(suite.T(), testLogDirectory, gsdkConfig.LogFolder)
 	assert.Equal(suite.T(), testVmId, gsdkConfig.VmId)
 	assert.Equal(suite.T(), testGameServerName, gsdkConfig.SessionHostId)
+	assert.Equal(suite.T(), testNodeInternalIP, gsdkConfig.PublicIpV4Address)
+	assert.Equal(suite.T(), testNodeInternalIP, gsdkConfig.GameServerConnectionInfo.PublicIpV4Address)
 
 	portsMap, ports, err := parsePorts()
 	assert.NoError(suite.T(), err)
@@ -86,6 +89,7 @@ func setEnvVariables() {
 	os.Setenv("PF_GAMESERVER_NAMESPACE", testGameServerNamespace)
 	os.Setenv("PF_GAMESERVER_PORTS", testGameServerPorts)
 	os.Setenv("PF_GAMESERVER_BUILD_METADATA", testBuildMetadata)
+	os.Setenv("PF_NODE_INTERNAL_IP", testNodeInternalIP)
 }
 
 func unsetEnvVariables() {
@@ -99,4 +103,5 @@ func unsetEnvVariables() {
 	os.Unsetenv("PF_GAMESERVER_NAMESPACE")
 	os.Unsetenv("PF_GAMESERVER_PORTS")
 	os.Unsetenv("PF_GAMESERVER_BUILD_METADATA")
+	os.Unsetenv("PF_NODE_INTERNAL_IP")
 }

--- a/operator/controllers/utilities.go
+++ b/operator/controllers/utilities.go
@@ -276,8 +276,20 @@ func getInitContainerEnvVariables(gs *mpsv1alpha1.GameServer) []corev1.EnvVar {
 			Value: LogDirectory,
 		},
 		{
-			Name:  "PF_VM_ID",
-			Value: "thundernetes-aks-cluster",
+			Name: "PF_VM_ID",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			},
+		},
+		{
+			Name: "PF_NODE_INTERNAL_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.hostIP",
+				},
+			},
 		},
 		{
 			Name:  "PF_GAMESERVER_NAME", // this becomes SessionHostId in gsdkConfig.json file


### PR DESCRIPTION
Fixes #53 

This PR adds the Node Internal IP to the list of environment variables obtained by the initcontainer and passed into the gsdkConfig.json file. This is used in the GetPublicIP API of the GSDK. Workarounds will be provided in the documentation for users that want to obtain the actual Public (External) IP. We also opportunistically fixed getting the actual Node name passed in "PF_VM_ID" environment variable.

#86 gets the actual Public IP but the code was deemed "too much".