### PR TITLE
.net 6 for .NET sample and open arena

### DIFF
--- a/samples/netcore/Dockerfile
+++ b/samples/netcore/Dockerfile
@@ -1,8 +1,8 @@
-﻿FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine AS base
+﻿FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine AS base
 WORKDIR /app
 EXPOSE 56001
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS build
 WORKDIR /src
 COPY ["netcore.csproj", ""]
 RUN dotnet restore "./netcore.csproj"
@@ -11,11 +11,10 @@ WORKDIR "/src/."
 RUN dotnet build "netcore.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "netcore.csproj" -c Release -o /app/publish --runtime alpine-x64 
+RUN dotnet publish "netcore.csproj" -c Release -o /app/publish
     #--self-contained true \
     #/p:PublishTrimmed=true \
     #/p:PublishSingleFile=true
-
 
 FROM base AS final
 WORKDIR /app

--- a/samples/netcore/netcore.csproj
+++ b/samples/netcore/netcore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/openarena/Dockerfile
+++ b/samples/openarena/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /source
 
 # copy csproj and restore as distinct layers
@@ -7,7 +7,7 @@ RUN dotnet restore
 
 # copy and publish app and libraries
 COPY . .
-RUN dotnet publish -c release -o /app -r linux-x64
+RUN dotnet publish -c release -o /app
 
 # final stage/image
 FROM fgracia/openarena:latest

--- a/samples/openarena/openarena.csproj
+++ b/samples/openarena/openarena.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Signed-off-by: Dimitrios Ilias Gkanatsios <dgkanatsios@outlook.com>

Converting netcore sample and openarena to work with .NET 6. Moreover, removing the x64 build from the `botnet publish` command. This has the effect of building for whatever architecture the container is running on, enabling the end to end tests to run on MacOS with M1 (Apple Silicon) processor.