### PR TITLE
reverting old values for the quickstart

### DIFF
--- a/installfiles/operator.yaml
+++ b/installfiles/operator.yaml
@@ -8080,7 +8080,7 @@ spec:
           value: ghcr.io/playfab/thundernetes-sidecar-go:0.1.0
         - name: THUNDERNETES_INIT_CONTAINER_IMAGE
           value: ghcr.io/playfab/thundernetes-initcontainer:0.1.0
-        - name: TLS_SECRET_NAMESPACE
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/installfiles/operator_with_monitoring.yaml
+++ b/installfiles/operator_with_monitoring.yaml
@@ -8080,7 +8080,7 @@ spec:
           value: ghcr.io/playfab/thundernetes-sidecar-go:0.1.0
         - name: THUNDERNETES_INIT_CONTAINER_IMAGE
           value: ghcr.io/playfab/thundernetes-initcontainer:0.1.0
-        - name: TLS_SECRET_NAMESPACE
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/installfiles/operator_with_security.yaml
+++ b/installfiles/operator_with_security.yaml
@@ -8080,7 +8080,7 @@ spec:
           value: ghcr.io/playfab/thundernetes-sidecar-go:0.1.0
         - name: THUNDERNETES_INIT_CONTAINER_IMAGE
           value: ghcr.io/playfab/thundernetes-initcontainer:0.1.0
-        - name: TLS_SECRET_NAMESPACE
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace

--- a/installfiles/operator_with_security_and_monitoring.yaml
+++ b/installfiles/operator_with_security_and_monitoring.yaml
@@ -8080,7 +8080,7 @@ spec:
           value: ghcr.io/playfab/thundernetes-sidecar-go:0.1.0
         - name: THUNDERNETES_INIT_CONTAINER_IMAGE
           value: ghcr.io/playfab/thundernetes-initcontainer:0.1.0
-        - name: TLS_SECRET_NAMESPACE
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace


### PR DESCRIPTION
A recent PR introduced a change in the environment variable that the operator uses to look for a potential TLS secret. While e2e tests worked for newer commits, version 0.1 (the one in the current quickstart) fails to start. The PR fixes it.