### PR TITLE
increasing timeout in an effort to fix flaky test

### DIFF
--- a/operator/controllers/gameserverbuild_controller.go
+++ b/operator/controllers/gameserverbuild_controller.go
@@ -236,6 +236,8 @@ func (r *GameServerBuildReconciler) updateStatus(ctx context.Context, gsb *mpsv1
 		gsb.Status.CrashesCount = gsb.Status.CrashesCount + crashesCount
 		gsb.Status.CurrentStandingByReadyDesired = fmt.Sprintf("%d/%d", standingByCount, gsb.Spec.StandingBy)
 
+		r.Recorder.Event(gsb, corev1.EventTypeNormal, "Status Updated", fmt.Sprintf("pending %d, initializing %d, active %d, standingBy %d, crashes %d, total crashes %d", pendingCount, initializingCount, activeCount, standingByCount, crashesCount, gsb.Status.CrashesCount))
+
 		if gsb.Status.CrashesCount >= gsb.Spec.CrashesToMarkUnhealthy {
 			gsb.Status.Health = mpsv1alpha1.BuildUnhealthy
 		} else {

--- a/operator/controllers/gameserverbuild_controller_test.go
+++ b/operator/controllers/gameserverbuild_controller_test.go
@@ -195,7 +195,7 @@ func verifyThatBuildIsUnhealthy(ctx context.Context, buildName string) {
 		err := k8sClient.Get(ctx, types.NamespacedName{Name: buildName, Namespace: testnamespace}, &gameServerBuild)
 		Expect(err).ShouldNot(HaveOccurred())
 		return gameServerBuild.Status.Health == mpsv1alpha1.BuildUnhealthy
-	}, assertTimeout, assertPollingInterval).Should(BeTrue())
+	}, 2*assertTimeout, assertPollingInterval).Should(BeTrue()) // trying double timeout since this test has been flaky
 }
 
 func waitTillCountGameServersAreInitializing(ctx context.Context, buildID string, count int) {


### PR DESCRIPTION
This PR increases the timeout in an effort to fix a specific flaky test which has been failing a number of times, last one is here https://github.com/PlayFab/thundernetes/runs/4551304482?check_suite_focus=true. Unfortunately we were not able to repro locally, even by running the test 100 times :( .