### PR TITLE
fixes for Unity GSDK

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -62,6 +62,10 @@ You can use the following steps to setup fluentbit to capture logs from your Gam
 
 Scaling in Kubernetes is two fold. Pod autoscaling and Cluster autoscaling. Thundernetes enables pod autoscaling by default utilizing the standby mechanism. For Node autoscaling, Kubernetes cluster autoscaler can be potentially used, especially with the use of [overprovisioning](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-can-i-configure-overprovisioning-with-cluster-autoscaler). If you are using Azure Kubernetes Service, you can [easily enable cluster autoscaler](https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler).
 
+## Can I run a Unity or Unreal game server on thundernetes?
+
+You can run any game server that supports the [PlayFab GameServer SDK](https://github.com/PlayFab/gsdk). Check a Unity sample [here](../samples/unity/README.md).
+
 ## Virtual Kubelet
 
 In conjuction with cluster autoscaler, you can use [Virtual Kubelet](https://github.com/virtual-kubelet/virtual-kubelet) project to accelerate the addition of new Pods to the cluster. If you are using Azure Kubernetes Service, you can easily enable Virtual Nodes feature (which is based on Virtual Kubelet) using the instructions [here](https://docs.microsoft.com/en-us/azure/aks/virtual-nodes).

--- a/nodeagent/utilities.go
+++ b/nodeagent/utilities.go
@@ -22,10 +22,12 @@ func badRequest(w http.ResponseWriter, err error, msg string) {
 }
 
 func validateHeartbeatRequestArgs(hb *HeartbeatRequest) error {
-	var msg string
+	// some GSDKs (e.g. Unity) send empty string as Health
+	// we should accept it and set it to Healthy, till this is fixed
 	if hb.CurrentGameHealth == "" {
-		msg = "CurrentGameHealth cannot be empty"
+		hb.CurrentGameHealth = "Healthy"
 	}
+	var msg string
 	if hb.CurrentGameState == "" {
 		msg = fmt.Sprintf("%s - CurrentGameState cannot be empty", msg)
 	}

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -11,4 +11,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: docker.io/dgkanatsios/thundernetes-operator
-  newTag: 4295c91
+  newTag: 107ed9f

--- a/samples/unity/README.md
+++ b/samples/unity/README.md
@@ -1,0 +1,5 @@
+# Running Unity servers on thundernetes
+
+Unity game servers are supported on thundernetes. The only thing you need to is add the Unity GSDK to your project. You can download the Unity GSDK from [here](https://github.com/PlayFab/gsdk/tree/master/UnityGsdk), check the documentation [here](https://docs.microsoft.com/en-us/gaming/playfab/features/multiplayer/servers/mps-unity). You can find a Unity sample integrated with the [Mirror Network SDK](https://mirror-networking.com/) in the [PlayFab GSDK Samples](https://github.com/PlayFab/MpsSamples/tree/master/UnityMirror).
+
+As soon as you built the Unity server container image, you can create a GameServerBuild on thundernetes using a file like [this](./sample.yaml).

--- a/samples/unity/sample.yaml
+++ b/samples/unity/sample.yaml
@@ -1,0 +1,33 @@
+apiVersion: mps.playfab.com/v1alpha1
+kind: GameServerBuild
+metadata:
+  name: gameserverbuild-sample-unity
+spec:
+  titleID: "1E03" # required
+  buildID: "85ffe8da-c82f-4035-86c5-9d2b5f42d6f7" # must be a GUID
+  standingBy: 2 # required
+  max: 4 # required
+  crashesToMarkUnhealthy: 5 # optional, default is 5. It is the number of crashes needed to mark the build unhealthy
+  buildMetadata: # optional. Retrievable via GSDK
+    - key: "buildMetadataKey1"
+      value: "buildMetadataValue1"
+    - key: "buildMetadataKey1"
+      value: "buildMetadataValue1"
+  portsToExpose:
+    - containerName: thundernetes-sample-netcore # must be the same as the container name described below
+      portName: gameport # must be the same as the port name described below
+  podSpec:
+    containers:
+      - image: docker.io/dgkanatsios/thundernetes-unity:0.1
+        name: thundernetes-sample-netcore
+        ports:
+        - containerPort: 7777 # your game server port
+          protocol: TCP # your game server port protocol
+          name: gameport # required field
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            cpu: 100m
+            memory: 500Mi


### PR DESCRIPTION
This PR partially fixes #60.
It adds some documentation for running Unity game servers on thundernetes. Moreover, since the [Unity GSDK](https://github.com/PlayFab/gsdk/tree/master/UnityGsdk) does not send any information, we modified the NodeAgent to convert empty strings to "Healthy". 