### PR TITLE
Support setting GameServers Pods to host network

### DIFF
--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -35,6 +35,7 @@ const (
 	invalidStatusCode         string = "invalid status code"
 	containerName             string = "netcore-sample" // this must be the same as the GameServer name
 	nodeAgentName             string = "nodeagent"
+	portKey                   string = "gameport"
 )
 
 type AllocationResult struct {
@@ -109,7 +110,7 @@ func main() {
 		Spec: mpsv1alpha1.GameServerBuildSpec{
 			BuildID:       test1BuildID,
 			TitleID:       "1E03",
-			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: "myport"}},
+			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: portKey}},
 			BuildMetadata: []mpsv1alpha1.BuildMetadataItem{
 				{Key: "metadatakey1", Value: "metadatavalue1"},
 				{Key: "metadatakey2", Value: "metadatavalue2"},
@@ -125,7 +126,7 @@ func main() {
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Ports: []corev1.ContainerPort{
 							{
-								Name:          "myport",
+								Name:          portKey,
 								ContainerPort: 80,
 							},
 						},
@@ -144,7 +145,7 @@ func main() {
 		Spec: mpsv1alpha1.GameServerBuildSpec{
 			BuildID:       testBuildSleepBeforeReadyForPlayersID,
 			TitleID:       "1E03",
-			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: "myport"}},
+			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: portKey}},
 			StandingBy:    2,
 			Max:           4,
 			PodSpec: corev1.PodSpec{
@@ -155,7 +156,7 @@ func main() {
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Ports: []corev1.ContainerPort{
 							{
-								Name:          "myport",
+								Name:          portKey,
 								ContainerPort: 80,
 							},
 						},
@@ -180,7 +181,7 @@ func main() {
 		Spec: mpsv1alpha1.GameServerBuildSpec{
 			BuildID:       testCrashingBuildID,
 			TitleID:       "1E03",
-			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: "myport"}},
+			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: portKey}},
 			StandingBy:    2,
 			Max:           4,
 			PodSpec: corev1.PodSpec{
@@ -192,7 +193,7 @@ func main() {
 						Command:         []string{"/bin/sh", "-c", "sleep 2 && command_that_does_not_exist"},
 						Ports: []corev1.ContainerPort{
 							{
-								Name:          "myport",
+								Name:          portKey,
 								ContainerPort: 80,
 							},
 						},
@@ -211,7 +212,7 @@ func main() {
 		Spec: mpsv1alpha1.GameServerBuildSpec{
 			BuildID:       testWithoutReadyForPlayersBuildID,
 			TitleID:       "1E03",
-			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: "myport"}},
+			PortsToExpose: []mpsv1alpha1.PortToExpose{{ContainerName: "netcore-sample", PortName: portKey}},
 			StandingBy:    2,
 			Max:           4,
 			PodSpec: corev1.PodSpec{
@@ -222,7 +223,7 @@ func main() {
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Ports: []corev1.ContainerPort{
 							{
-								Name:          "myport",
+								Name:          portKey,
 								ContainerPort: 80,
 							},
 						},

--- a/docs/yourgameserver.md
+++ b/docs/yourgameserver.md
@@ -88,3 +88,7 @@ gameserverbuild-sample-spdob   Healthy   StandingBy   172.18.0.2   80:14208
 ## Run your game server on Azure Kubernetes Service
 
 As soon as you build your container image, you should publish it to a container registry. If you are using Azure Kubernetes Service, we recommend publishing your image to [Azure Container Registry](https://docs.microsoft.com/en-us/azure/container-registry/). To integrate your Azure Container Registry with your Azure Kubernetes Service cluster, check the instructions [here](https://docs.microsoft.com/en-us/azure/aks/cluster-container-registry-integration).
+
+## Using host networking
+
+Thundernetes supports running your GameServer Pods under host networking. To do that, you need to provide a GameServerBuild YAML like [this](../samples/netcore/sample-hostnetwork.yaml). During Pod creation, thundernetes will override the containerPort with the same value that will be assigned in the hostPort.

--- a/docs/yourgameserver.md
+++ b/docs/yourgameserver.md
@@ -91,4 +91,6 @@ As soon as you build your container image, you should publish it to a container 
 
 ## Using host networking
 
-Thundernetes supports running your GameServer Pods under host networking. To do that, you need to provide a GameServerBuild YAML like [this](../samples/netcore/sample-hostnetwork.yaml). During Pod creation, thundernetes will override the containerPort with the same value that will be assigned in the hostPort.
+Thundernetes supports running your GameServer Pods under host networking. To do that, you need to provide a GameServerBuild YAML like [this](../samples/netcore/sample-hostnetwork.yaml), setting the `hostNetwork` value to true on PodSpec template. During Pod creation, thundernetes controllers will override the containerPort with the same value that will be assigned in the hostPort. 
+
+> Unfortunately, it is still necessary to provide a `containerPort` value in the GameServerBuild YAML, since it is required for GameServerBuild validation. However, as mentioned, this provided value is used nowhere since it's overwritten by the `hostPort` value.

--- a/pkg/operator/controllers/utilities.go
+++ b/pkg/operator/controllers/utilities.go
@@ -134,6 +134,11 @@ func NewGameServerForGameServerBuild(gsb *mpsv1alpha1.GameServerBuild, portRegis
 					return nil, err
 				}
 				container.Ports[i].HostPort = port
+
+				// if the user has specified that they want to use the host's network, we override the container port
+				if gsb.Spec.PodSpec.HostNetwork {
+					container.Ports[i].ContainerPort = port
+				}
 			}
 		}
 	}

--- a/samples/netcore/Program.cs
+++ b/samples/netcore/Program.cs
@@ -31,7 +31,7 @@ namespace netcore
             }
             else
             {
-                Console.WriteLine($"Cannot find gameport in GSDK Config Settings. Check your YAML definitions");
+                Console.WriteLine("Cannot find gameport in GSDK Config Settings. Check your YAML definition");
                 return;
             }
 

--- a/samples/netcore/Program.cs
+++ b/samples/netcore/Program.cs
@@ -12,8 +12,9 @@ namespace netcore
 {
     class Program
     {
-        const int HTTP_PORT = 80;
         private static DateTimeOffset _nextMaintenance = DateTimeOffset.MinValue;
+        private static int httpPort;
+        private static string httpPortKey = "gameport";
         static void Main(string[] args)
         {
             GameserverSDK.Start(true);
@@ -22,6 +23,17 @@ namespace netcore
             GameserverSDK.RegisterHealthCallback(IsHealthy);
             GameserverSDK.RegisterMaintenanceCallback(OnMaintenanceScheduled);
             
+            IDictionary<string, string> initialConfig = GameserverSDK.getConfigSettings();
+            // Start the http server
+            if (initialConfig?.ContainsKey(httpPortKey) == true)
+            {
+                httpPort = int.Parse(initialConfig[httpPortKey]);
+            }
+            else
+            {
+                Console.WriteLine($"Cannot find gameport in GSDK Config Settings. Check your YAML definitions");
+                return;
+            }
 
             Console.WriteLine($"Welcome to fake game server!");
             if(args.Length > 0)
@@ -39,7 +51,7 @@ namespace netcore
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder.UseStartup<Startup>();
-                webBuilder.UseUrls($"http://*:{HTTP_PORT}");
+                webBuilder.UseUrls($"http://*:{httpPort}");
             });
 
 

--- a/samples/netcore/sample-hostNetwork.yaml
+++ b/samples/netcore/sample-hostNetwork.yaml
@@ -1,0 +1,33 @@
+apiVersion: mps.playfab.com/v1alpha1
+kind: GameServerBuild
+metadata:
+  name: gameserverbuild-sample-netcore
+spec:
+  titleID: "1E03" # required
+  buildID: "85ffe8da-c82f-4035-86c5-9d2b5f42d6f6" # must be a GUID
+  standingBy: 2 # required
+  max: 4 # required
+  crashesToMarkUnhealthy: 5 # optional, default is 5. It is the number of crashes needed to mark the build unhealthy
+  buildMetadata: # optional. Retrievable via GSDK
+    - key: "buildMetadataKey1"
+      value: "buildMetadataValue1"
+    - key: "buildMetadataKey1"
+      value: "buildMetadataValue1"
+  portsToExpose:
+    - containerName: thundernetes-sample-netcore # must be the same as the container name described below
+      portName: gameport # must be the same as the port name described below
+  podSpec:
+    hostNetwork: true # this sample uses host networking
+    containers:
+      - image: ghcr.io/playfab/thundernetes-netcore-sample:0.1.0
+        name: thundernetes-sample-netcore
+        ports:
+        - protocol: TCP # your game server port protocol
+          name: gameport # required field
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            cpu: 100m
+            memory: 500Mi

--- a/samples/netcore/sample-hostNetwork.yaml
+++ b/samples/netcore/sample-hostNetwork.yaml
@@ -24,6 +24,7 @@ spec:
         ports:
         - protocol: TCP # your game server port protocol
           name: gameport # required field
+          containerPort: 80 # this is required because of podSpec validation but it's overwritten during Pod creation
         resources:
           requests:
             cpu: 100m

--- a/samples/netcore/sample-hostnetwork.yaml
+++ b/samples/netcore/sample-hostnetwork.yaml
@@ -1,7 +1,7 @@
 apiVersion: mps.playfab.com/v1alpha1
 kind: GameServerBuild
 metadata:
-  name: gameserverbuild-sample-netcore
+  name: gameserverbuild-sample-netcore-hostnetwork
 spec:
   titleID: "1E03" # required
   buildID: "85ffe8da-c82f-4035-86c5-9d2b5f42d6f6" # must be a GUID
@@ -19,7 +19,7 @@ spec:
   podSpec:
     hostNetwork: true # this sample uses host networking
     containers:
-      - image: ghcr.io/playfab/thundernetes-netcore-sample:0.1.0
+      - image: ghcr.io/playfab/thundernetes-netcore-sample:0.2.0 # works only on version 0.2 
         name: thundernetes-sample-netcore
         ports:
         - protocol: TCP # your game server port protocol

--- a/samples/netcore/sample-nodeaffinity.yaml
+++ b/samples/netcore/sample-nodeaffinity.yaml
@@ -1,7 +1,7 @@
 apiVersion: mps.playfab.com/v1alpha1
 kind: GameServerBuild
 metadata:
-  name: gameserverbuild-sample-netcore
+  name: gameserverbuild-sample-netcore-nodeaffinity
 spec:
   titleID: "1E03" # required
   buildID: "85ffe8da-c82f-4035-86c5-9d2b5f42d6f6" # must be a GUID

--- a/samples/netcore/sample-secondnodepool.yaml
+++ b/samples/netcore/sample-secondnodepool.yaml
@@ -1,7 +1,7 @@
 apiVersion: mps.playfab.com/v1alpha1
 kind: GameServerBuild
 metadata:
-  name: gameserverbuild-sample-netcore
+  name: gameserverbuild-sample-netcore-secondnodepool
 spec:
   titleID: "1E03" # required
   buildID: "85ffe8da-c82f-4035-86c5-9d2b5f42d6f6" # must be a GUID


### PR DESCRIPTION
Fixes #22 

This PR enables the utilization of hostNetwork mode on GameServer Pods, if selected by the user. It also

- adapts netcore sample so it loads the port via GSDKConfig (best practice on MPS as well, but old code should still work).
- adds a unit test for hostNetwork mode
- adds a relevant sample
- fixes naming on sample files for consistency