### PR TITLE
ignore game servers under deletion

### DIFF
--- a/pkg/operator/http/http.go
+++ b/pkg/operator/http/http.go
@@ -52,7 +52,10 @@ func NewApiServer(mgr ctrl.Manager, crt, key []byte) error {
 func (s *ApiServer) setupIndexers(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &mpsv1alpha1.GameServer{}, "status.state", func(rawObj client.Object) []string {
 		gs := rawObj.(*mpsv1alpha1.GameServer)
-		return []string{string(gs.Status.State)}
+		if gs.DeletionTimestamp == nil {
+			return []string{string(gs.Status.State)}
+		}
+		return nil
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR improves the allocation API service by ignoring GameServer custom resources that are being deleted.