### PR TITLE
replacing patch with update during allocation

### DIFF
--- a/pkg/operator/http/allocate.go
+++ b/pkg/operator/http/allocate.go
@@ -127,12 +127,11 @@ func (h *allocateHandler) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// set the relevant status fields
-	patch := client.MergeFrom(gs.DeepCopy())
 	gs.Status.State = mpsv1alpha1.GameServerStateActive
 	gs.Status.SessionID = args.SessionID
 	gs.Status.SessionCookie = args.SessionCookie
 
-	err = h.client.Status().Patch(r.Context(), &gs, patch)
+	err = h.client.Status().Update(r.Context(), &gs)
 	if err != nil {
 		internalServerError(ctx, w, err, "cannot update game server")
 		return


### PR DESCRIPTION
Current allocation logic with PATCH the .status.state of a GameServer Custom Resource with the new "Active" state. However, there are cases in which this might create issues since PATCH does not check the current state of the object. For example, the object might have been deleted or crashed and the cache might have not been updated. This will lead to the allocation API service returning an invalid active game server to the caller. To prevent this, we are switching the Patch with Update which will fail if the object's state has changed. 
For the time being, this will require the customer to implement a retry logic till we can implement some retry logic ourselves, maybe as part of #7.