### PR TITLE
unblocking unhealthy GameServerBuild

### DIFF
--- a/docs/gameserverbuild.md
+++ b/docs/gameserverbuild.md
@@ -40,3 +40,7 @@ The template.spec contains the definition for a [Kubernetes Pod](https://kuberne
 ## PortsToExpose
 
 This is a list of containerName/portName tuples: These are the ports that you want to be exposed in the [Worker Node/VM](https://kubernetes.io/docs/concepts/architecture/nodes/) when the Pod is created. The way this works is that each Pod you create will have >=1 number of containers. There, each container will have its own *Ports* definition. If a port in this definition is included in the *portsToExpose* array, this port will be publicly exposed in the Node/VM. This is accomplished by the setting of a **hostPort** value for each of the container ports you want to expose. The reason we need this is that because i) you may want to use some ports on your Pod containers for other purposes rather than players connecting to it and ii) a portName must be unique within a container. Ports assigned are in the port range 10000-50000.
+
+## CrashesToMarkUnhealthy
+
+CrashesToMarkUnhealthy (integet) is the number of crashes that you want to trigger the GameServerBuild to become Unhealthy. Once this happens, no other operation will take place on the GameServerBuild. To allow thundernets to continue performing reconciliations on the GameServerBuild after it has become Unhealthy, you can increase the value of the CrashesToMarkUnhealthy field. The GameServerBuild will be marked as Healthy again till the number of crashes reaches the value of CrashesToMarkUnhealthy.

--- a/pkg/operator/controllers/gameserverbuild_controller.go
+++ b/pkg/operator/controllers/gameserverbuild_controller.go
@@ -92,8 +92,8 @@ func (r *GameServerBuildReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	// if GameServerBuild is unhealthy, do nothing more
-	if gsb.Status.Health == mpsv1alpha1.BuildUnhealthy {
+	// if GameServerBuild is unhealthy and current crashes equal or more than the crashesToMarkUnhealthy, so do nothing more
+	if gsb.Status.Health == mpsv1alpha1.BuildUnhealthy && gsb.Status.CrashesCount >= gsb.Spec.CrashesToMarkUnhealthy {
 		log.Info("GameServerBuild is unhealthy, do nothing")
 		r.Recorder.Event(&gsb, corev1.EventTypeNormal, "Unhealthy Build", "GameServerBuild is unhealthy, do nothing")
 		return ctrl.Result{}, nil


### PR DESCRIPTION
Fixes #155 

Currently, once the GameServerBuild becomes unhealthy, no other operation (controller reconciliation) will take place on the GameServerBuild. This can be a blocker on some scenarios where we want this to continue. We need to think of a better overall solution, but for the time being this PR allows the user to increase the value of the GameServerBuild.Spec.CrashesToMarkUnhealthy so the controller will continue to perform reconciliations on it.