### PR TITLE
fixing goroutine sync on portregistry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,11 +36,11 @@ jobs:
       - name: build Docker images
         run: make builddockerlocal
       - name: GameServer API service unit tests
-        run: cd cmd/gameserverapi && GIN_MODE=release go test
+        run: cd cmd/gameserverapi && GIN_MODE=release go test -race
       - name: initcontainer unit tests
-        run: cd cmd/initcontainer && go test
+        run: cd cmd/initcontainer && go test -race
       - name: nodeagent unit tests
-        run: cd cmd/nodeagent && go test
+        run: cd cmd/nodeagent && go test -race
       - name: operator unit tests
         run: IMAGE_NAME_SAMPLE=thundernetes-netcore IMAGE_NAME_INIT_CONTAINER=thundernetes-initcontainer TAG=$(git rev-list HEAD --max-count=1 --abbrev-commit) make -C pkg/operator test
       - name: install kind binaries

--- a/cmd/nodeagent/nodeagentmanager_test.go
+++ b/cmd/nodeagent/nodeagentmanager_test.go
@@ -122,9 +122,10 @@ var _ = Describe("nodeagent tests", func() {
 			if !ok {
 				return false
 			}
-			defer tempgs.(*GameServerDetails).Mutex.RUnlock()
 			tempgs.(*GameServerDetails).Mutex.RLock()
-			return tempgs.(*GameServerDetails).WasActivated && tempgs.(*GameServerDetails).PreviousGameState == GameStateStandingBy
+			gsd := *tempgs.(*GameServerDetails)
+			tempgs.(*GameServerDetails).Mutex.RUnlock()
+			return gsd.WasActivated && gsd.PreviousGameState == GameStateStandingBy
 		}).Should(BeTrue())
 
 		// heartbeat from the game is still StandingBy
@@ -205,12 +206,13 @@ var _ = Describe("nodeagent tests", func() {
 				// wait for the update trigger on the watch
 				Eventually(func() bool {
 					tempgs, ok := n.gameServerMap.Load(randomGameServerName)
-					defer tempgs.(*GameServerDetails).Mutex.RUnlock()
-					tempgs.(*GameServerDetails).Mutex.RLock()
 					if !ok {
 						return false
 					}
-					return tempgs.(*GameServerDetails).WasActivated && tempgs.(*GameServerDetails).PreviousGameState == GameStateStandingBy
+					tempgs.(*GameServerDetails).Mutex.RLock()
+					gsd := *tempgs.(*GameServerDetails)
+					tempgs.(*GameServerDetails).Mutex.RUnlock()
+					return gsd.WasActivated && tempgs.(*GameServerDetails).PreviousGameState == GameStateStandingBy
 				}).Should(BeTrue())
 
 				// heartbeat from the game is still StandingBy

--- a/cmd/nodeagent/nodeagentmanager_test.go
+++ b/cmd/nodeagent/nodeagentmanager_test.go
@@ -122,6 +122,8 @@ var _ = Describe("nodeagent tests", func() {
 			if !ok {
 				return false
 			}
+			defer tempgs.(*GameServerDetails).Mutex.RUnlock()
+			tempgs.(*GameServerDetails).Mutex.RLock()
 			return tempgs.(*GameServerDetails).WasActivated && tempgs.(*GameServerDetails).PreviousGameState == GameStateStandingBy
 		}).Should(BeTrue())
 
@@ -203,6 +205,8 @@ var _ = Describe("nodeagent tests", func() {
 				// wait for the update trigger on the watch
 				Eventually(func() bool {
 					tempgs, ok := n.gameServerMap.Load(randomGameServerName)
+					defer tempgs.(*GameServerDetails).Mutex.RUnlock()
+					tempgs.(*GameServerDetails).Mutex.RLock()
 					if !ok {
 						return false
 					}

--- a/pkg/operator/Makefile
+++ b/pkg/operator/Makefile
@@ -62,7 +62,7 @@ vet: ## Run go vet against code.
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" THUNDERNETES_SAMPLE_IMAGE=$(IMAGE_NAME_SAMPLE):$(NETCORE_SAMPLE_TAG) THUNDERNETES_INIT_CONTAINER_IMAGE=$(IMAGE_NAME_INIT_CONTAINER):$(IMAGE_TAG) go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" THUNDERNETES_SAMPLE_IMAGE=$(IMAGE_NAME_SAMPLE):$(NETCORE_SAMPLE_TAG) THUNDERNETES_INIT_CONTAINER_IMAGE=$(IMAGE_NAME_INIT_CONTAINER):$(IMAGE_TAG) go test -race ./... -coverprofile cover.out
 	
 ##@ Build
 

--- a/pkg/operator/controllers/port_registry.go
+++ b/pkg/operator/controllers/port_registry.go
@@ -141,10 +141,11 @@ func (pr *PortRegistry) DeregisterServerPorts(ports []int32) error {
 	defer pr.HostPortsMutex.Unlock()
 	pr.HostPortsMutex.Lock()
 	for i := 0; i < len(ports); i++ {
-		if _, ok := pr.HostPorts[ports[i]]; !ok {
-			return fmt.Errorf("port %d is not registered in HostPorts", ports[i])
+		p := ports[i]
+		if _, ok := pr.HostPorts[p]; !ok {
+			return fmt.Errorf("port %d is not registered in HostPorts", p)
 		}
-		pr.HostPorts[ports[i]] = false
+		pr.HostPorts[p] = false
 	}
 	return nil
 }

--- a/pkg/operator/controllers/port_registry_test.go
+++ b/pkg/operator/controllers/port_registry_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Port registry tests", Ordered, func() {
 		for i := 0; i < 7; i++ {
 			peekPort, err := peekNextPort(portRegistry)
 			actualPort, _ := portRegistry.GetNewPort()
-			Expect(actualPort).To(BeIdenticalTo(peekPort), fmt.Sprintf("Wrong port returned, peekPort:%d, actualPort:%d", peekPort, actualPort))
+			Expect(actualPort).To(Equal(peekPort), fmt.Sprintf("Wrong port returned, peekPort:%d, actualPort:%d", peekPort, actualPort))
 			Expect(err).ToNot(HaveOccurred())
 
 			registeredPorts[i] = actualPort
@@ -99,7 +99,7 @@ var _ = Describe("Port registry tests", Ordered, func() {
 	It("should return another port", func() {
 		peekPort, err := peekNextPort(portRegistry)
 		actualPort, _ := portRegistry.GetNewPort()
-		Expect(actualPort).To(BeNumerically("==", peekPort), fmt.Sprintf("Wrong port returned, peekPort:%d,actualPort:%d", peekPort, actualPort))
+		Expect(actualPort).To(Equal(peekPort), fmt.Sprintf("Wrong port returned, peekPort:%d,actualPort:%d", peekPort, actualPort))
 		Expect(err).ToNot(HaveOccurred())
 
 		assignedPorts[actualPort] = true
@@ -115,11 +115,11 @@ var _ = Describe("Port registry tests", Ordered, func() {
 	})
 })
 
-var _ = Describe("Port registry with ten thousand ports", func() {
+var _ = Describe("Port registry with one thousand ports", func() {
 	rand.Seed(time.Now().UnixNano())
 	log := logr.FromContextOrDiscard(context.Background())
 	min := int32(20000)
-	max := int32(29999)
+	max := int32(20999)
 	portRegistry, err := NewPortRegistry(mpsv1alpha1.GameServerList{}, min, max, log)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -127,13 +127,13 @@ var _ = Describe("Port registry with ten thousand ports", func() {
 	It("should work with allocating and deallocating ports", func() {
 		go portRegistry.portProducer()
 
-		// allocate all 10000 ports
+		// allocate all 1000 ports
 		var wg sync.WaitGroup
 		for i := 0; i < int(max-min+1); i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				n := rand.Intn(200) + 100 // n will be between 100 and 300
+				n := rand.Intn(200) + 50 // n will be between 50 and 250
 				time.Sleep(time.Duration(n) * time.Millisecond)
 				port, err := portRegistry.GetNewPort()
 				Expect(err).ToNot(HaveOccurred())
@@ -158,12 +158,12 @@ var _ = Describe("Port registry with ten thousand ports", func() {
 		_, err := portRegistry.GetNewPort()
 		Expect(err).To(HaveOccurred())
 
-		//deallocate the 5000 even ports
+		//deallocate the 500 even ports
 		for i := 0; i < int(max-min+1)/2; i++ {
 			wg.Add(1)
 			go func(portToDeallocate int) {
 				defer wg.Done()
-				n := rand.Intn(200) + 100 // n will be between 100 and 300
+				n := rand.Intn(200) + 50 // n will be between 50 and 250
 				time.Sleep(time.Duration(n) * time.Millisecond)
 				err := portRegistry.DeregisterServerPorts([]int32{int32(portToDeallocate)})
 				Expect(err).ToNot(HaveOccurred())
@@ -180,12 +180,12 @@ var _ = Describe("Port registry with ten thousand ports", func() {
 		verifyAssignedHostPorts(portRegistry, m)
 		verifyUnassignedHostPorts(portRegistry, m)
 
-		// allocate 5000 ports
+		// allocate 500 ports
 		for i := 0; i < int(max-min+1)/2; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				n := rand.Intn(200) + 100 // n will be between 100 and 300
+				n := rand.Intn(200) + 50 // n will be between 50 and 250
 				time.Sleep(time.Duration(n) * time.Millisecond)
 				port, err := portRegistry.GetNewPort()
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -75,10 +75,15 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	// generate a port registry for the tests
+	portRegistry, err := NewPortRegistry(mpsv1alpha1.GameServerList{}, 20000, 20100, ctrl.Log)
+	Expect(err).ToNot(HaveOccurred())
+
 	err = (&GameServerBuildReconciler{
-		Client:   k8sManager.GetClient(),
-		Scheme:   k8sManager.GetScheme(),
-		Recorder: k8sManager.GetEventRecorderFor("GameServerBuildReconciler"),
+		Client:       k8sManager.GetClient(),
+		Scheme:       k8sManager.GetScheme(),
+		PortRegistry: portRegistry,
+		Recorder:     k8sManager.GetEventRecorderFor("GameServerBuildReconciler"),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -86,6 +91,7 @@ var _ = BeforeSuite(func() {
 		Client:                     k8sManager.GetClient(),
 		Scheme:                     k8sManager.GetScheme(),
 		Recorder:                   k8sManager.GetEventRecorderFor("GameServerReconciler"),
+		PortRegistry:               portRegistry,
 		GetPublicIpForNodeProvider: func(_ context.Context, _ client.Reader, _ string) (string, error) { return "testPublicIP", nil },
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Wrote some tests for portRegistry and discovered that there would have been issues with massive game server allocation and deallocation. This PR adds mutex locks in the PortRegistry structure plus necessary testing.