### PR TITLE
Test allocate wrong tls credentials

### DIFF
--- a/cmd/e2e/allocation_test.go
+++ b/cmd/e2e/allocation_test.go
@@ -118,8 +118,7 @@ var _ = Describe("test GameServerBuild with allocation tests", Ordered, func() {
 	It("should fail to allocate with wrong TLS certificate", func() {
 		sessionID1_8 := uuid.New().String()
 		err := allocate(testBuildAllocationID, sessionID1_8, fakeCert)
-		// TODO: verify that the error is a tls/authentication error
-		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tls: bad certificate"))
 		Eventually(func(g Gomega) {
 			state := buildState{
 				buildName:       testBuildAllocationName,

--- a/cmd/e2e/allocation_test.go
+++ b/cmd/e2e/allocation_test.go
@@ -18,12 +18,15 @@ var _ = Describe("test GameServerBuild with allocation tests", Ordered, func() {
 	testBuildAllocationName := "testbuildallocation"
 	testBuildAllocationID := "85ffe8da-c82f-4035-86c5-9d2b5f42d6aa"
 	var cert tls.Certificate
+	var fakeCert tls.Certificate
 	ctx := context.Background()
 	var kubeClient client.Client
 	var coreClient *kubernetes.Clientset
 	BeforeAll(func() {
 		var err error
 		cert, err = tls.LoadX509KeyPair(certFile, keyFile)
+		Expect(err).ToNot(HaveOccurred())
+		fakeCert, err = tls.LoadX509KeyPair(fakeCertFile, fakeKeyFile)
 		Expect(err).ToNot(HaveOccurred())
 		kubeConfig := ctrl.GetConfigOrDie()
 		kubeClient, err = createKubeClient(kubeConfig)
@@ -111,4 +114,21 @@ var _ = Describe("test GameServerBuild with allocation tests", Ordered, func() {
 		Expect(validateThatAllocatedServersHaveReadyForPlayersUnblocked(ctx, kubeClient, coreClient, testBuildAllocationID, 1)).To(Succeed())
 
 	})
+
+	It("should fail to allocate with wrong TLS certificate", func() {
+		// shouldn't be able to allocate, expecting zero actives
+		sessionID1_8 := uuid.New().String()
+		Expect(allocate(testBuildAllocationID, sessionID1_8, fakeCert)).To(Succeed())
+		Eventually(func(g Gomega) {
+			state := buildState{
+				buildName:       testBuildAllocationName,
+				buildID:         testBuildAllocationID,
+				standingByCount: 2,
+				podRunningCount: 2,
+				gsbHealth:       mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+		}, timeout, interval).Should(Succeed())
+	})
+
 })

--- a/cmd/e2e/allocation_test.go
+++ b/cmd/e2e/allocation_test.go
@@ -116,15 +116,17 @@ var _ = Describe("test GameServerBuild with allocation tests", Ordered, func() {
 	})
 
 	It("should fail to allocate with wrong TLS certificate", func() {
-		// shouldn't be able to allocate, expecting zero actives
 		sessionID1_8 := uuid.New().String()
-		Expect(allocate(testBuildAllocationID, sessionID1_8, fakeCert)).To(Succeed())
+		err := allocate(testBuildAllocationID, sessionID1_8, fakeCert)
+		// TODO: verify that the error is a tls/authentication error
+		Expect(err).To(HaveOccurred())
 		Eventually(func(g Gomega) {
 			state := buildState{
 				buildName:       testBuildAllocationName,
 				buildID:         testBuildAllocationID,
 				standingByCount: 2,
-				podRunningCount: 2,
+				activeCount:     1,
+				podRunningCount: 3,
 				gsbHealth:       mpsv1alpha1.BuildHealthy,
 			}
 			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())

--- a/cmd/e2e/suite_test.go
+++ b/cmd/e2e/suite_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 var (
-	img      string
-	certFile string
-	keyFile  string
+	img          string
+	certFile     string
+	keyFile      string
+	fakeCertFile string
+	fakeKeyFile  string
 )
 
 func TestEndToEnd(t *testing.T) {
@@ -28,4 +30,8 @@ var _ = BeforeSuite(func() {
 	Expect(certFile).ToNot(BeEmpty())
 	keyFile = os.Getenv("TLS_PRIVATE")
 	Expect(keyFile).ToNot(BeEmpty())
+	fakeCertFile = os.Getenv("FAKE_TLS_PUBLIC")
+	Expect(fakeCertFile).ToNot(BeEmpty())
+	fakeKeyFile = os.Getenv("FAKE_TLS_PRIVATE")
+	Expect(fakeKeyFile).ToNot(BeEmpty())
 })

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -30,6 +30,11 @@ openssl req -x509 -newkey rsa:4096 -nodes -keyout ${TLS_PRIVATE} -out ${TLS_PUBL
 kubectl create namespace thundernetes-system
 kubectl create secret tls tls-secret -n thundernetes-system --cert=${TLS_PUBLIC} --key=${TLS_PRIVATE}
 
+# fake certificate for testing the TLS security on the allocation API server
+export FAKE_TLS_PRIVATE=/tmp/${RANDOM}.pem
+export FAKE_TLS_PUBLIC=/tmp/${RANDOM}.pem
+openssl req -x509 -newkey rsa:4096 -nodes -keyout ${FAKE_TLS_PRIVATE} -out ${FAKE_TLS_PUBLIC} -days 365 -subj '/CN=localhost'
+
 echo "-----Compiling, building and deploying the operator to local Kubernetes cluster-----"
 IMG=${IMAGE_NAME_OPERATOR}:${IMAGE_TAG} API_SERVICE_SECURITY=usetls make -C "${DIR}"/../pkg/operator deploy
 

--- a/pkg/operator/config/manager/kustomization.yaml
+++ b/pkg/operator/config/manager/kustomization.yaml
@@ -11,4 +11,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: thundernetes-operator
-  newTag: a7cbf9c
+  newTag: dcc9988

--- a/pkg/operator/http/types.go
+++ b/pkg/operator/http/types.go
@@ -1,9 +1,7 @@
 package http
 
 import (
-	"net"
 	"regexp"
-	"time"
 )
 
 // AllocateArgs contains information necessary to allocate a GameServer
@@ -33,23 +31,4 @@ type RequestMultiplayerServerResponse struct {
 	IPV4Address string
 	Ports       string
 	SessionID   string
-}
-
-// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
-// connections. It's used by ListenAndServe and ListenAndServeTLS so
-// dead TCP connections (e.g. closing laptop mid-download) eventually
-// go away. We use if for TLS-auth enabled allocation API service
-type tcpKeepAliveListener struct {
-	*net.TCPListener
-}
-
-// Accept accepts the TCP connection and sets the TCP keep-alive for 3 minutes
-func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
-	tc, err := ln.AcceptTCP()
-	if err != nil {
-		return
-	}
-	tc.SetKeepAlive(true)
-	tc.SetKeepAlivePeriod(3 * time.Minute)
-	return tc, nil
 }


### PR DESCRIPTION
Added a test that checks that you can't allocate gameservers when using a wrong TLS certificates.