### PR TITLE
splitting tests in unit/e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+name: E2E
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+        debug_enabled:
+          description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
+          required: false
+          default: "false"
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Setup Go environment
+        uses: actions/setup-go@v2.1.3
+        with:
+          # The Go version to download (if necessary) and use. Supports semver spec and ranges.
+          go-version: 1.17.x
+      - name: build Docker images
+        run: make builddockerlocal
+      - name: install kind binaries
+        run: make installkind
+      - name: create kind cluster
+        run: make createkindcluster
+      - name: run end-to-end tests
+        run: make e2elocal
+      - name: Setup tmate session # instructions on https://github.com/marketplace/actions/debugging-with-tmate
+        if: ${{ failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true' }}
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,6 +1,4 @@
-# This is a basic workflow to help you get started with Actions
-
-name: CI
+name: Unit
 
 # Controls when the workflow will run
 on:
@@ -12,11 +10,6 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-    inputs:
-        debug_enabled:
-          description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'     
-          required: false
-          default: "false"
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -32,9 +25,7 @@ jobs:
         uses: actions/setup-go@v2.1.3
         with:
           # The Go version to download (if necessary) and use. Supports semver spec and ranges.
-          go-version: 1.17.5
-      - name: build Docker images
-        run: make builddockerlocal
+          go-version: 1.17.x
       - name: GameServer API service unit tests
         run: cd cmd/gameserverapi && GIN_MODE=release go test -race
       - name: initcontainer unit tests
@@ -43,12 +34,3 @@ jobs:
         run: cd cmd/nodeagent && go test -race
       - name: operator unit tests
         run: IMAGE_NAME_SAMPLE=thundernetes-netcore IMAGE_NAME_INIT_CONTAINER=thundernetes-initcontainer TAG=$(git rev-list HEAD --max-count=1 --abbrev-commit) make -C pkg/operator test
-      - name: install kind binaries
-        run: make installkind
-      - name: create kind cluster
-        run: make createkindcluster
-      - name: run end-to-end tests
-        run: make e2elocal
-      - name: Setup tmate session # instructions on https://github.com/marketplace/actions/debugging-with-tmate
-        if: ${{ failure() && github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled == 'true' }}
-        uses: mxschmitt/action-tmate@v3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/PlayFab/thundernetes/actions/workflows/main.yml/badge.svg)](https://github.com/PlayFab/thundernetes/actions/workflows/main.yml)
+[![E2E](https://github.com/PlayFab/thundernetes/actions/workflows/e2e.yml/badge.svg)](https://github.com/PlayFab/thundernetes/actions/workflows/main.yml)
 [![Software License](https://img.shields.io/badge/license-Apache-brightgreen.svg?style=flat-square)](LICENSE)
 [![GitHub release](https://img.shields.io/github/release/playfab/thundernetes.svg)](https://github.com/playfab/thundernetes/releases)
 ![](https://img.shields.io/badge/status-beta-lightgreen.svg)


### PR DESCRIPTION
Currently unit tests and integration (end to end) tests are executed synchronously during PRs/merges. This PR splits them into two, so hopefully the workflow will finish earlier.