### PR TITLE
specifying latest 1.17 go version for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-go@v2.1.3
         with:
           # The Go version to download (if necessary) and use. Supports semver spec and ranges.
-          go-version: 1.17.5
+          go-version: 1.17.x
       - name: build Docker images
         run: make builddockerlocal
       - name: GameServer API service unit tests


### PR DESCRIPTION
This PR updates the CI test to use 1.17.x of Go instead of 1.17.5