### PR TITLE
creating log folders on InitContainer

### DIFF
--- a/cmd/initcontainer/main.go
+++ b/cmd/initcontainer/main.go
@@ -60,7 +60,10 @@ func main() {
 
 	setLogLevel()
 
-	getRestEnvVariables()
+	getGsdkEnvVariables()
+
+	err := createGsdkFolders()
+	handleError(err)
 
 	gamePorts, gamePortConfiguration, err := parsePorts()
 	if err != nil {
@@ -176,17 +179,17 @@ func checkEnvOrFatal(envName string, envValue string) {
 func getGameServerNameNamespaceFromEnv() {
 	sessionHostId = os.Getenv("PF_GAMESERVER_NAME")
 	if sessionHostId == "" {
-		panic("PF_GAMESERVER_NAME is empty")
+		handleError(errors.New("PF_GAMESERVER_NAME is empty"))
 	}
 
 	crdNamespace = os.Getenv("PF_GAMESERVER_NAMESPACE")
 	if crdNamespace == "" {
-		panic("PF_GAMESERVER_NAMESPACE is empty")
+		handleError(errors.New("PF_GAMESERVER_NAMESPACE is empty"))
 	}
 }
 
-// getRestEnvVariables gets the rest environment variables
-func getRestEnvVariables() {
+// getGsdkEnvVariables gets the GSDK environment variables
+func getGsdkEnvVariables() {
 	heartbeatEndpointPort = os.Getenv("HEARTBEAT_ENDPOINT_PORT")
 	checkEnvOrFatal("HEARTBEAT_ENDPOINT_PORT", heartbeatEndpointPort)
 
@@ -223,4 +226,25 @@ func setLogLevel() {
 	}
 
 	log.SetLevel(logLevel)
+}
+
+// createFolderIfNotExists creates the folder if it does not exist
+func createFolderIfNotExists(path string) error {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(path, os.ModePerm)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// createGsdkFolders creates the folders for the GSDK related methods
+func createGsdkFolders() error {
+	// for the time being, we create only the server log folder
+	err := createFolderIfNotExists(serverLogPath)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/operator/controllers/utilities.go
+++ b/pkg/operator/controllers/utilities.go
@@ -333,6 +333,10 @@ func getGameServerEnvVariables(gs *mpsv1alpha1.GameServer) []corev1.EnvVar {
 			Name:  "PF_TITLE_ID",
 			Value: gs.Spec.TitleID,
 		},
+		{
+			Name:  "PF_SERVER_LOG_DIRECTORY",
+			Value: LogDirectory,
+		},
 	}
 
 	return envList


### PR DESCRIPTION
Fixes #197 
This PR does two things

- it adds a method on initContainer which creates a log folder for the GSDK to access, if needed
- it adds an environment variable on game server with the location of this log folder. This is useful for Unreal game server builds, since on MPS they have to change the log folder permissions, as per https://github.com/PlayFab/gsdk/blob/main/UnrealPlugin/ThirdPersonMPCloudDeploy.md#startupsh-bash-script