### PR TITLE
making the architecture image link

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ nav_order: 8
 
 This document describes the architecture of Thundernetes as well as various design notes that are relevant to its implementation.
 
-![Architecture diagram](assets/images/diagram.png)
+[![Architecture diagram](assets/images/diagram.png)](assets/images/diagram.png)
 
 ## Goal
 


### PR DESCRIPTION
The architecture image looks quite small when it appears on the site. This PR makes it linkable to the full image. 