### PR TITLE
checking if make create-install-files makes the repo dirty

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           # The Go version to download (if necessary) and use. Supports semver spec and ranges.
           go-version: 1.17.x
+      - name: check if install files are modified
+        run: |
+          make -C pkg/operator kustomize
+          make create-install-files
+          if ! [ -z "$(git status --porcelain)" ]; then
+            echo "install files are modified"
+            exit 1
+          fi
       - name: build Docker images
         run: make builddockerlocal
       - name: GameServer API service unit tests

--- a/pkg/operator/Makefile
+++ b/pkg/operator/Makefile
@@ -138,7 +138,7 @@ KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/k
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
 $(KUSTOMIZE):
-	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
+	mkdir -p $(LOCALBIN) && curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Fixes #134 

This PR adds an extra step into our CI pipeline where it will generate the install files (`make create-install-files`) and then check if the repo has been dirty. This is for cases where we upgrade dependent libraries (e.g. controller-runtime) and this will change the YAML generated files that our operator is based on. In these cases, we should create a new Thundernetes version.