### PR TITLE
Deleting Unhealthy game servers

### DIFF
--- a/cmd/e2e/build_crashing_test.go
+++ b/cmd/e2e/build_crashing_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Crashing Build", func() {
 
 		Eventually(func(g Gomega) {
 			var gsList mpsv1alpha1.GameServerList
-			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{"BuildName": testBuildCrashingName})
+			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildCrashingName})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(gsList.Items)).To(Equal(2))
 			gs := gsList.Items[0]

--- a/cmd/e2e/build_host_network_test.go
+++ b/cmd/e2e/build_host_network_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Build with hostnetwork", func() {
 
 		Eventually(func(g Gomega) {
 			var gsList mpsv1alpha1.GameServerList
-			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{"BuildName": testBuildWithHostNetworkName})
+			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildWithHostNetworkName})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(gsList.Items)).To(Equal(3))
 			gs := gsList.Items[0]

--- a/cmd/e2e/build_sleep_before_readyforplayers_test.go
+++ b/cmd/e2e/build_sleep_before_readyforplayers_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Build which sleeps before calling GSDK ReadyForPlayers", func(
 
 		Eventually(func(g Gomega) {
 			var gsList mpsv1alpha1.GameServerList
-			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{"BuildName": testBuildSleepBeforeReadyForPlayersName})
+			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildSleepBeforeReadyForPlayersName})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(gsList.Items)).To(Equal(3))
 			gs := gsList.Items[0]

--- a/cmd/e2e/build_unhealthy_gameservers_test.go
+++ b/cmd/e2e/build_unhealthy_gameservers_test.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	mpsv1alpha1 "github.com/playfab/thundernetes/pkg/operator/api/v1alpha1"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// this file contains tests to verify that Unhealthy GameServers get deleted
+// this test checks if StandingBy and Active GameServers that are marked as Unhealthy are properly deleted
+var _ = Describe("Regular GameServerBuild", func() {
+	testBuildWithUnhealthyGameServersName := "unhealthygameservers"
+	testBuildWithUnhealthyGameServersID := "8512e812-c82f-4b45-86c5-9d2b1ae3d6f6"
+	It("should delete the Unhealthy GameServers and replace them with Healthy ones", func() {
+		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx := context.Background()
+		kubeConfig := ctrl.GetConfigOrDie()
+		kubeClient, err := createKubeClient(kubeConfig)
+		Expect(err).ToNot(HaveOccurred())
+		err = kubeClient.Create(ctx, createE2eBuild(testBuildWithUnhealthyGameServersName, testBuildWithUnhealthyGameServersID, img))
+		Expect(err).ToNot(HaveOccurred())
+
+		coreClient, err := kubernetes.NewForConfig(kubeConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			state := buildState{
+				buildName:       testBuildWithUnhealthyGameServersName,
+				buildID:         testBuildWithUnhealthyGameServersID,
+				standingByCount: 2,
+				podRunningCount: 2,
+				gsbHealth:       mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+		}, timeout, interval).Should(Succeed())
+
+		// update the standingBy to 3
+		gsb := &mpsv1alpha1.GameServerBuild{}
+		err = kubeClient.Get(ctx, client.ObjectKey{Name: testBuildWithUnhealthyGameServersName, Namespace: testNamespace}, gsb)
+		Expect(err).ToNot(HaveOccurred())
+		patch := client.MergeFrom(gsb.DeepCopy())
+		gsb.Spec.StandingBy = 3
+		err = kubeClient.Patch(ctx, gsb, patch)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			state := buildState{
+				buildName:       testBuildWithUnhealthyGameServersName,
+				buildID:         testBuildWithUnhealthyGameServersID,
+				standingByCount: 3,
+				podRunningCount: 3,
+				gsbHealth:       mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+		}, timeout, interval).Should(Succeed())
+
+		// get the names of the game servers so we can mark them as Unhealthy
+		// and later make sure that they disappeared
+		var gsList mpsv1alpha1.GameServerList
+		err = kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildWithUnhealthyGameServersName})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(gsList.Items)).To(Equal(3))
+
+		gsNames := make(map[string]interface{})
+		for _, gs := range gsList.Items {
+			gsNames[gs.Name] = struct{}{}
+		}
+
+		// mark these gameservers as Unhealthy
+		// under normal circumstances, this can happen if they never send a heartbeat, if they are late in sending a heartbeat
+		// or if they mark themselves as Unhealthy via the relevant GSDK call
+		// check NodeAgent for relevant code
+		for _, gs := range gsList.Items {
+			patch := client.MergeFrom(gs.DeepCopy())
+			gs.Status.Health = mpsv1alpha1.GameServerUnhealthy
+			err = kubeClient.Status().Patch(ctx, &gs, patch)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// make sure 3 new servers were created to replace the ones that were deleted
+		Eventually(func(g Gomega) {
+			state := buildState{
+				buildName:       testBuildWithUnhealthyGameServersName,
+				buildID:         testBuildWithUnhealthyGameServersID,
+				standingByCount: 3,
+				podRunningCount: 3,
+				gsbHealth:       mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+
+			// get the names of the new game servers
+			var gsList mpsv1alpha1.GameServerList
+			err = kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildWithUnhealthyGameServersName})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(len(gsList.Items)).To(Equal(3))
+
+			// make sure they have different names than the ones that were deleted
+			for _, gs := range gsList.Items {
+				g.Expect(gs.Status.Health).To(Equal(mpsv1alpha1.GameServerHealthy))
+				_, ok := gsNames[gs.Name]
+				g.Expect(ok).To(BeFalse())
+			}
+
+		}, timeout, interval).Should(Succeed())
+
+		// allocate a game server
+		sessionID := uuid.New().String()
+		err = allocate(testBuildWithUnhealthyGameServersID, sessionID, cert)
+		Expect(err).ToNot(HaveOccurred())
+
+		// so we now should have 1 active and 3 standingBy
+		Eventually(func(g Gomega) {
+			state := buildState{
+				buildName:       testBuildWithUnhealthyGameServersName,
+				buildID:         testBuildWithUnhealthyGameServersID,
+				standingByCount: 3,
+				activeCount:     1,
+				podRunningCount: 4,
+				gsbHealth:       mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+		}, timeout, interval).Should(Succeed())
+
+		Expect(validateThatAllocatedServersHaveReadyForPlayersUnblocked(ctx, kubeClient, coreClient, testBuildWithUnhealthyGameServersID, 1)).To(Succeed())
+
+		// get the active game server so we can mark it as Unhealthy
+		// and later make sure that it was deleted
+		err = kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildWithUnhealthyGameServersName})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(gsList.Items)).To(Equal(4))
+
+		// get the active game server
+		var activeGs mpsv1alpha1.GameServer
+		for _, gs := range gsList.Items {
+			if gs.Status.State == mpsv1alpha1.GameServerStateActive {
+				activeGs = gs
+				break
+			}
+		}
+		Expect(activeGs.Name).ToNot(BeEmpty())
+
+		// mark this Active GameServer as Unhealthy
+		// to verify that the controller is deleting GameServers that are Active but they turn Unhealthy
+		patch = client.MergeFrom(activeGs.DeepCopy())
+		activeGs.Status.Health = mpsv1alpha1.GameServerUnhealthy
+		err = kubeClient.Status().Patch(ctx, &activeGs, patch)
+		Expect(err).ToNot(HaveOccurred())
+
+		// make sure the active was deleted and we have 3 standingBy
+		Eventually(func(g Gomega) {
+			state := buildState{
+				buildName:       testBuildWithUnhealthyGameServersName,
+				buildID:         testBuildWithUnhealthyGameServersID,
+				standingByCount: 3,
+				podRunningCount: 3,
+				gsbHealth:       mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+
+			// get the names of the game servers
+			var gsList mpsv1alpha1.GameServerList
+			err = kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildWithUnhealthyGameServersName})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(len(gsList.Items)).To(Equal(3))
+
+			// make sure they have different names than the active that we deleted
+			for _, gs := range gsList.Items {
+				g.Expect(gs.Status.Health).To(Equal(mpsv1alpha1.GameServerHealthy))
+				g.Expect(gs.Name).ToNot(Equal(activeGs.Name))
+			}
+
+		}, timeout, interval).Should(Succeed())
+	})
+})
+
+// this test verifies that GameServers that do not call the ReadyForPlayers() GSDK method (thus, they stay stuck in Initializing state)
+// and are marked as Unhealthy for any reason (e.g. missing heartbeat)
+// will eventually be deleted
+var _ = Describe("GameServerBuild with Unhealthy GameServers without ReadyForPlayers", func() {
+	testBuildUnhealthyGameServersWithoutReadyForPlayersName := "withoutreadyforplayersunhealthy"
+	testBuildUnhealthyGameServersWithoutReadyForPlayersID := "85ffe8da-c82f-a12e-86c5-9d2b7652d6f8"
+	It("should delete unhealthy GameServers and replace them with healthy ones", func() {
+		ctx := context.Background()
+		kubeConfig := ctrl.GetConfigOrDie()
+		kubeClient, err := createKubeClient(kubeConfig)
+		Expect(err).ToNot(HaveOccurred())
+		err = kubeClient.Create(ctx, createBuildWithoutReadyForPlayers(testBuildUnhealthyGameServersWithoutReadyForPlayersName, testBuildUnhealthyGameServersWithoutReadyForPlayersID, img))
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			gsb := &mpsv1alpha1.GameServerBuild{}
+			err := kubeClient.Get(ctx, client.ObjectKey{Name: testBuildUnhealthyGameServersWithoutReadyForPlayersName, Namespace: testNamespace}, gsb)
+			g.Expect(err).ToNot(HaveOccurred())
+			state := buildState{
+				buildName:         testBuildUnhealthyGameServersWithoutReadyForPlayersName,
+				buildID:           testBuildUnhealthyGameServersWithoutReadyForPlayersID,
+				initializingCount: 2,
+				standingByCount:   0,
+				podRunningCount:   2,
+				gsbHealth:         mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+		}, timeout, interval).Should(Succeed())
+
+		// get the names of the game servers so we can mark them as Unhealthy
+		// and later make sure that they disappeared
+		var gsList mpsv1alpha1.GameServerList
+		err = kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildUnhealthyGameServersWithoutReadyForPlayersName})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(gsList.Items)).To(Equal(2))
+
+		gsNames := make(map[string]interface{})
+		for _, gs := range gsList.Items {
+			gsNames[gs.Name] = struct{}{}
+		}
+
+		// mark these GameServers as Unhealthy
+		for _, gs := range gsList.Items {
+			patch := client.MergeFrom(gs.DeepCopy())
+			gs.Status.Health = mpsv1alpha1.GameServerUnhealthy
+			err = kubeClient.Status().Patch(ctx, &gs, patch)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// make sure 2 more servers were created to replace the ones that were deleted
+		Eventually(func(g Gomega) {
+			state := buildState{
+				buildName:         testBuildUnhealthyGameServersWithoutReadyForPlayersName,
+				buildID:           testBuildUnhealthyGameServersWithoutReadyForPlayersID,
+				initializingCount: 2,
+				standingByCount:   0,
+				podRunningCount:   2,
+				gsbHealth:         mpsv1alpha1.BuildHealthy,
+			}
+			g.Expect(verifyGameServerBuildOverall(ctx, kubeClient, state)).To(Succeed())
+
+			// get the names of the new game servers
+			var gsList mpsv1alpha1.GameServerList
+			err = kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildUnhealthyGameServersWithoutReadyForPlayersName})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(len(gsList.Items)).To(Equal(2))
+
+			// make sure they have different names than the ones that were deleted
+			for _, gs := range gsList.Items {
+				g.Expect(gs.Status.Health).To(Equal(mpsv1alpha1.GameServerHealthy))
+				_, ok := gsNames[gs.Name]
+				g.Expect(ok).To(BeFalse())
+			}
+
+		}, timeout, interval).Should(Succeed())
+
+	})
+})
+
+// this test verifies that GameServers that do not integrate with GSDK and are marked as Unhealthy
+// will eventually be deleted
+var _ = Describe("GameServerBuild with GameServers without Gsdk", func() {
+	testBuildWithoutGsdkName := "withoutgsdk"
+	testBuildWithoutGsdkID := "8511e8da-c82f-a12e-86c5-9d2b76528356"
+	It("should delete unhealthy GameServers and replace them with healthy ones", func() {
+		ctx := context.Background()
+		kubeConfig := ctrl.GetConfigOrDie()
+		kubeClient, err := createKubeClient(kubeConfig)
+		Expect(err).ToNot(HaveOccurred())
+		err = kubeClient.Create(ctx, createBuildWithoutGsdk(testBuildWithoutGsdkName, testBuildWithoutGsdkID, img))
+		Expect(err).ToNot(HaveOccurred())
+
+		// get the names of all the game servers so we can mark them as Unhealthy
+		// this simulates the NodeAgent marking these GameServers as unhealthy
+		// because they didn't send a heartbeat within a period of time (which will be the case for GameServers that don't implement GSDK)
+		var gsList mpsv1alpha1.GameServerList
+		Eventually(func(g Gomega) {
+			err = kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildWithoutGsdkName})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(len(gsList.Items)).To(Equal(2))
+		}, timeout, interval).Should(Succeed())
+
+		// mark these GameServers as Unhealthy
+		for _, gs := range gsList.Items {
+			patch := client.MergeFrom(gs.DeepCopy())
+			gs.Status.Health = mpsv1alpha1.GameServerUnhealthy
+			err = kubeClient.Status().Patch(ctx, &gs, patch)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// make sure that GameServerBuild is Unhealthy (since CrashesToMarkUnhealthy threshold was reached)
+		Eventually(func(g Gomega) {
+			gsb := &mpsv1alpha1.GameServerBuild{}
+			err := kubeClient.Get(ctx, client.ObjectKey{Name: testBuildWithoutGsdkName, Namespace: testNamespace}, gsb)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(gsb.Status.Health).To(Equal(mpsv1alpha1.BuildUnhealthy))
+			g.Expect(gsb.Status.CrashesCount >= 2).To(BeTrue())
+		}, timeout, interval).Should(Succeed())
+
+	})
+})
+
+// createBuildWithoutGsdk creates a GameServerBuild without GSDK
+func createBuildWithoutGsdk(buildName, buildID, img string) *mpsv1alpha1.GameServerBuild {
+	gsb := createTestBuild(buildName, buildID, img)
+	gsb.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh", "-c", "sleep 3600"}
+	gsb.Spec.CrashesToMarkUnhealthy = 2
+
+	return gsb
+}

--- a/cmd/e2e/build_without_readyforplayers_test.go
+++ b/cmd/e2e/build_without_readyforplayers_test.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("Build without ReadyForPlayers GSDK call", func() {
+var _ = Describe("GameServerBuild without ReadyForPlayers GSDK call", func() {
 	testBuildWithoutReadyForPlayers := "withoutreadyforplayers"
 	testWithoutReadyForPlayersBuildID := "85ffe8da-c82f-4035-86c5-9d2b5f42d6f8"
 	It("should have GameServers stuck in Initializing", func() {
@@ -112,7 +112,7 @@ var _ = Describe("Build without ReadyForPlayers GSDK call", func() {
 
 		Eventually(func(g Gomega) {
 			var gsList mpsv1alpha1.GameServerList
-			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{"BuildName": testBuildWithoutReadyForPlayers})
+			err := kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: testBuildWithoutReadyForPlayers})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(gsList.Items)).To(Equal(2))
 			gs := gsList.Items[0]

--- a/cmd/e2e/utilities_test.go
+++ b/cmd/e2e/utilities_test.go
@@ -33,6 +33,7 @@ const (
 	testNamespace                      = "e2e"
 	connectedPlayersCount              = 3 // this should the same as in the netcore sample
 	LabelBuildID                       = "BuildID"
+	LabelBuildName                     = "BuildName"
 	invalidStatusCode           string = "invalid status code"
 	containerName               string = "netcore-sample" // this must be the same as the GameServer name
 	nodeAgentName               string = "nodeagent"
@@ -314,7 +315,7 @@ func verifyPodsInHostNetwork(ctx context.Context, kubeClient client.Client, gsb 
 	var pods = corev1.PodList{}
 	opts := []client.ListOption{
 		client.InNamespace(gsb.Namespace),
-		client.MatchingLabels{"BuildName": gsb.Name, "BuildID": gsb.Spec.BuildID},
+		client.MatchingLabels{LabelBuildName: gsb.Name, "BuildID": gsb.Spec.BuildID},
 	}
 
 	if err := kubeClient.List(ctx, &pods, opts...); err != nil {

--- a/cmd/gameserverapi/main.go
+++ b/cmd/gameserverapi/main.go
@@ -32,6 +32,7 @@ const (
 	gameServerDetailNameParam = "gameServerDetailName"
 	urlprefix                 = "/api/v1"
 	listeningPort             = 5001
+	LabelBuildName            = "BuildName"
 )
 
 func main() {
@@ -173,7 +174,7 @@ func listGameServers(c *gin.Context) {
 func listGameServersForBuild(c *gin.Context) {
 	buildName := c.Param(buildNameParam)
 	var gsList mpsv1alpha1.GameServerList
-	err := kubeClient.List(ctx, &gsList, client.MatchingLabels{"BuildName": buildName})
+	err := kubeClient.List(ctx, &gsList, client.MatchingLabels{LabelBuildName: buildName})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
@@ -304,7 +305,7 @@ func deleteGameServerBuild(c *gin.Context) {
 func listGameServerDetailsForBuild(c *gin.Context) {
 	buildName := c.Param(buildNameParam)
 	var gsdList mpsv1alpha1.GameServerDetailList
-	err := kubeClient.List(ctx, &gsdList, client.MatchingLabels{"BuildName": buildName})
+	err := kubeClient.List(ctx, &gsdList, client.MatchingLabels{LabelBuildName: buildName})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})

--- a/installfiles/operator.yaml
+++ b/installfiles/operator.yaml
@@ -292,7 +292,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -322,7 +322,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -377,7 +377,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -407,7 +407,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -461,7 +461,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -491,7 +491,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -546,7 +546,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -576,7 +576,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -598,12 +598,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -718,7 +718,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -874,7 +874,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1010,7 +1010,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1221,7 +1221,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1410,12 +1410,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -1530,7 +1530,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -1686,7 +1686,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1822,7 +1822,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2033,7 +2033,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2215,7 +2215,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -2230,12 +2230,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -2350,7 +2350,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -2506,7 +2506,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2642,7 +2642,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2853,7 +2853,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3014,7 +3014,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -3029,10 +3029,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -3057,7 +3057,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -3228,11 +3228,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -3253,138 +3257,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -3395,38 +3399,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -3481,21 +3485,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -3524,12 +3528,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3545,7 +3549,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3561,7 +3565,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -3583,7 +3587,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -3613,13 +3617,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3627,48 +3631,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -3678,119 +3682,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3798,92 +3802,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3894,11 +3898,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -3949,22 +3953,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3975,21 +3979,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -3998,103 +4002,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4102,26 +4106,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -4129,49 +4133,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4568,7 +4572,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4598,7 +4602,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4653,7 +4657,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4683,7 +4687,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4737,7 +4741,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4767,7 +4771,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4822,7 +4826,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4852,7 +4856,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4874,12 +4878,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -4994,7 +4998,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5150,7 +5154,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5286,7 +5290,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5497,7 +5501,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5686,12 +5690,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -5806,7 +5810,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5962,7 +5966,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6098,7 +6102,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6309,7 +6313,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6491,7 +6495,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -6506,12 +6510,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -6626,7 +6630,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -6782,7 +6786,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6918,7 +6922,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7129,7 +7133,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7290,7 +7294,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -7305,10 +7309,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -7333,7 +7337,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -7504,11 +7508,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -7529,138 +7537,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -7671,38 +7679,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -7757,21 +7765,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -7800,12 +7808,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7821,7 +7829,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7837,7 +7845,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -7859,7 +7867,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -7889,13 +7897,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -7903,48 +7911,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -7954,119 +7962,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -8074,92 +8082,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8170,11 +8178,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -8225,22 +8233,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8251,21 +8259,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -8274,103 +8282,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -8378,26 +8386,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8405,49 +8413,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath

--- a/installfiles/operator_with_monitoring.yaml
+++ b/installfiles/operator_with_monitoring.yaml
@@ -292,7 +292,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -322,7 +322,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -377,7 +377,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -407,7 +407,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -461,7 +461,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -491,7 +491,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -546,7 +546,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -576,7 +576,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -598,12 +598,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -718,7 +718,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -874,7 +874,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1010,7 +1010,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1221,7 +1221,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1410,12 +1410,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -1530,7 +1530,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -1686,7 +1686,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1822,7 +1822,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2033,7 +2033,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2215,7 +2215,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -2230,12 +2230,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -2350,7 +2350,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -2506,7 +2506,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2642,7 +2642,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2853,7 +2853,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3014,7 +3014,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -3029,10 +3029,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -3057,7 +3057,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -3228,11 +3228,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -3253,138 +3257,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -3395,38 +3399,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -3481,21 +3485,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -3524,12 +3528,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3545,7 +3549,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3561,7 +3565,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -3583,7 +3587,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -3613,13 +3617,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3627,48 +3631,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -3678,119 +3682,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3798,92 +3802,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3894,11 +3898,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -3949,22 +3953,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3975,21 +3979,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -3998,103 +4002,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4102,26 +4106,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -4129,49 +4133,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4568,7 +4572,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4598,7 +4602,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4653,7 +4657,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4683,7 +4687,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4737,7 +4741,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4767,7 +4771,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4822,7 +4826,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4852,7 +4856,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4874,12 +4878,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -4994,7 +4998,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5150,7 +5154,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5286,7 +5290,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5497,7 +5501,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5686,12 +5690,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -5806,7 +5810,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5962,7 +5966,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6098,7 +6102,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6309,7 +6313,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6491,7 +6495,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -6506,12 +6510,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -6626,7 +6630,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -6782,7 +6786,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6918,7 +6922,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7129,7 +7133,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7290,7 +7294,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -7305,10 +7309,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -7333,7 +7337,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -7504,11 +7508,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -7529,138 +7537,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -7671,38 +7679,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -7757,21 +7765,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -7800,12 +7808,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7821,7 +7829,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7837,7 +7845,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -7859,7 +7867,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -7889,13 +7897,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -7903,48 +7911,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -7954,119 +7962,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -8074,92 +8082,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8170,11 +8178,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -8225,22 +8233,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8251,21 +8259,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -8274,103 +8282,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -8378,26 +8386,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8405,49 +8413,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath

--- a/installfiles/operator_with_security.yaml
+++ b/installfiles/operator_with_security.yaml
@@ -292,7 +292,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -322,7 +322,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -377,7 +377,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -407,7 +407,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -461,7 +461,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -491,7 +491,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -546,7 +546,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -576,7 +576,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -598,12 +598,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -718,7 +718,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -874,7 +874,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1010,7 +1010,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1221,7 +1221,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1410,12 +1410,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -1530,7 +1530,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -1686,7 +1686,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1822,7 +1822,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2033,7 +2033,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2215,7 +2215,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -2230,12 +2230,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -2350,7 +2350,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -2506,7 +2506,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2642,7 +2642,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2853,7 +2853,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3014,7 +3014,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -3029,10 +3029,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -3057,7 +3057,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -3228,11 +3228,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -3253,138 +3257,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -3395,38 +3399,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -3481,21 +3485,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -3524,12 +3528,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3545,7 +3549,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3561,7 +3565,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -3583,7 +3587,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -3613,13 +3617,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3627,48 +3631,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -3678,119 +3682,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3798,92 +3802,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3894,11 +3898,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -3949,22 +3953,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3975,21 +3979,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -3998,103 +4002,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4102,26 +4106,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -4129,49 +4133,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4568,7 +4572,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4598,7 +4602,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4653,7 +4657,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4683,7 +4687,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4737,7 +4741,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4767,7 +4771,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4822,7 +4826,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4852,7 +4856,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4874,12 +4878,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -4994,7 +4998,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5150,7 +5154,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5286,7 +5290,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5497,7 +5501,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5686,12 +5690,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -5806,7 +5810,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5962,7 +5966,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6098,7 +6102,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6309,7 +6313,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6491,7 +6495,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -6506,12 +6510,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -6626,7 +6630,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -6782,7 +6786,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6918,7 +6922,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7129,7 +7133,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7290,7 +7294,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -7305,10 +7309,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -7333,7 +7337,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -7504,11 +7508,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -7529,138 +7537,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -7671,38 +7679,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -7757,21 +7765,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -7800,12 +7808,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7821,7 +7829,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7837,7 +7845,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -7859,7 +7867,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -7889,13 +7897,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -7903,48 +7911,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -7954,119 +7962,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -8074,92 +8082,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8170,11 +8178,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -8225,22 +8233,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8251,21 +8259,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -8274,103 +8282,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -8378,26 +8386,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8405,49 +8413,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath

--- a/installfiles/operator_with_security_and_monitoring.yaml
+++ b/installfiles/operator_with_security_and_monitoring.yaml
@@ -292,7 +292,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -322,7 +322,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -377,7 +377,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -407,7 +407,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -461,7 +461,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -491,7 +491,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -546,7 +546,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -576,7 +576,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -598,12 +598,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -718,7 +718,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -874,7 +874,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1010,7 +1010,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1221,7 +1221,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1410,12 +1410,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -1530,7 +1530,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -1686,7 +1686,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1822,7 +1822,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2033,7 +2033,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2215,7 +2215,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -2230,12 +2230,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -2350,7 +2350,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -2506,7 +2506,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2642,7 +2642,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2853,7 +2853,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3014,7 +3014,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -3029,10 +3029,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -3057,7 +3057,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -3228,11 +3228,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -3253,138 +3257,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -3395,38 +3399,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -3481,21 +3485,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -3524,12 +3528,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3545,7 +3549,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -3561,7 +3565,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -3583,7 +3587,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -3613,13 +3617,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -3627,48 +3631,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -3678,119 +3682,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3798,92 +3802,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3894,11 +3898,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -3949,22 +3953,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -3975,21 +3979,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -3998,103 +4002,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4102,26 +4106,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -4129,49 +4133,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4568,7 +4572,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4598,7 +4602,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4653,7 +4657,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4683,7 +4687,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4737,7 +4741,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaceSelector:
-                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                          description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4767,7 +4771,7 @@ spec:
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                          description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4822,7 +4826,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaceSelector:
-                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                      description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -4852,7 +4856,7 @@ spec:
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                      description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -4874,12 +4878,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -4994,7 +4998,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5150,7 +5154,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5286,7 +5290,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5497,7 +5501,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -5686,12 +5690,12 @@ spec:
                           description: "An EphemeralContainer is a temporary container that you may add to an existing Pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a Pod is removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the Pod to exceed its resource allocation. \n To add an ephemeral container, use the ephemeralcontainers subresource of an existing Pod. Ephemeral containers may not be removed or restarted. \n This is a beta feature available on clusters that haven't disabled the EphemeralContainers feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -5806,7 +5810,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -5962,7 +5966,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6098,7 +6102,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6309,7 +6313,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6491,7 +6495,7 @@ spec:
                         description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
@@ -6506,12 +6510,12 @@ spec:
                           description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                              description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
@@ -6626,7 +6630,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
@@ -6782,7 +6786,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -6918,7 +6922,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7129,7 +7133,7 @@ spec:
                                   format: int32
                                   type: integer
                                 grpc:
-                                  description: GRPC specifies an action involving a GRPC port. This is an alpha field and requires enabling GRPCContainerProbe feature gate.
+                                  description: GRPC specifies an action involving a GRPC port. This is a beta field and requires enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
                                       description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -7290,7 +7294,7 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       os:
-                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is an alpha field and requires the IdentifyPodOS feature"
+                        description: "Specifies the OS of the containers in the pod. Some pod and container fields are restricted if this is set. \n If the OS field is set to linux, the following fields must be unset: -securityContext.windowsOptions \n If the OS field is set to windows, following fields must be unset: - spec.hostPID - spec.hostIPC - spec.securityContext.seLinuxOptions - spec.securityContext.seccompProfile - spec.securityContext.fsGroup - spec.securityContext.fsGroupChangePolicy - spec.securityContext.sysctls - spec.shareProcessNamespace - spec.securityContext.runAsUser - spec.securityContext.runAsGroup - spec.securityContext.supplementalGroups - spec.containers[*].securityContext.seLinuxOptions - spec.containers[*].securityContext.seccompProfile - spec.containers[*].securityContext.capabilities - spec.containers[*].securityContext.readOnlyRootFilesystem - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser - spec.containers[*].securityContext.runAsGroup This is a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system. The currently supported values are linux and windows. Additional value may be defined in future and can be one of: https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration Clients should expect to handle additional values and treat unrecognized values in this field as os: null'
@@ -7305,10 +7309,10 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md This field is beta-level as of Kubernetes v1.18, and is only honored by servers that enable the PodOverhead feature.'
+                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is beta-level, gated by the NonPreemptingPriority feature-gate.
+                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
@@ -7333,7 +7337,7 @@ spec:
                         description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class This is a beta feature as of Kubernetes v1.14.'
+                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
@@ -7504,11 +7508,15 @@ spec:
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. The global minimum is the minimum number of matching pods in an eligible domain or zero if the number of eligible domains is less than MinDomains. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 2/2/1: In this case, the global minimum is 1. | zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It''s a required field. Default value is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number of eligible domains. When the number of eligible domains with matching topology keys is less than minDomains, Pod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed. And when the number of eligible domains with matching topology keys equals or greater than minDomains, this value has no effect on scheduling. As a result, when the number of eligible domains is less than minDomains, scheduler won't schedule more than maxSkew Pods to those domains. If value is nil, the constraint behaves as if MinDomains is equal to 1. Valid values are integers greater than 0. When value is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same labelSelector spread as 2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  | The number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0. In this situation, new pod with the same labelSelector cannot be scheduled, because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones, it will violate MaxSkew. \n This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
+                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. We define a domain as a particular instance of a topology. Also, we define an eligible domain as a domain whose nodes match the node selector. e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology. And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology. It's a required field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location, but giving higher precedence to topologies that would help reduce the skew. A constraint is considered "Unsatisfiable" for an incoming pod if and only if every possible node assignment for that pod would violate "MaxSkew" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
@@ -7529,138 +7537,138 @@ spec:
                           description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                              description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
+                                  description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
+                                  description: diskName is the Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                  description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                              description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
+                                  description: secretName is the  name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                              description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
+                              description: configMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -7671,38 +7679,38 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
+                                  description: optional specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                              description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                  description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                  description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                  description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                  description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
+                              description: downwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
                                   description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
@@ -7757,21 +7765,21 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
+                              description: "ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed. \n Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity tracking are needed, c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource for more information on the connection between this volume type and PersistentVolumeClaim). \n Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod. \n Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information. \n A pod can use both types of ephemeral volumes and persistent volumes at the same time."
                               properties:
                                 volumeClaimTemplate:
                                   description: "Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long). \n An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster. \n This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created. \n Required, must not be nil."
@@ -7800,12 +7808,12 @@ spec:
                                       description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                                          description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7821,7 +7829,7 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                                          description: 'dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef preserves all values, and generates an error if a disallowed value is specified. (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
@@ -7837,7 +7845,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                           properties:
                                             limits:
                                               additionalProperties:
@@ -7859,7 +7867,7 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes to consider for binding.
+                                          description: selector is a label query over volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -7889,13 +7897,13 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                                          description: volumeName is the binding reference to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
                                   required:
@@ -7903,48 +7911,48 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                              description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                              description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
+                                  description: driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
+                                  description: 'options is Optional: this field holds extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
@@ -7954,119 +7962,119 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                              description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                  description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                              description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                  description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                              description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
+                              description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
+                                  description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
+                                  description: chapAuthSession defines whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                  description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
+                                  description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -8074,92 +8082,92 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                              description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
+                                  description: pdID is the ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                              description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
+                                  description: volumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
+                              description: projected items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                  description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
+                                        description: configMap information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8170,11 +8178,11 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
+                                            description: optional specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
+                                        description: downwardAPI information about the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume file
@@ -8225,22 +8233,22 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
+                                        description: secret information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                            description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -8251,21 +8259,21 @@ spec:
                                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
+                                            description: optional field specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
+                                        description: serviceAccountToken is information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                            description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                            description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
+                                            description: path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -8274,103 +8282,103 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                              description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
+                                  description: group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                  description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                  description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
+                                  description: user to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
+                                  description: volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                              description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
+                                  description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                              description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
+                                  description: gateway is the host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
+                                  description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                  description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                  description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
+                                  description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
+                                  description: system is the name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                  description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -8378,26 +8386,26 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                  description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
                                     description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -8405,49 +8413,49 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
+                                  description: optional field specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                              description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                  description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                  description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                  description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                              description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
+                                  description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
+                                  description: volumePath is the path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath

--- a/pkg/operator/api/v1alpha1/gameserver_types.go
+++ b/pkg/operator/api/v1alpha1/gameserver_types.go
@@ -38,8 +38,8 @@ const (
 )
 
 const (
-	Healthy   GameServerHealth = "Healthy"
-	Unhealthy GameServerHealth = "Unhealthy"
+	GameServerHealthy   GameServerHealth = "Healthy"
+	GameServerUnhealthy GameServerHealth = "Unhealthy"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/pkg/operator/config/crd/bases/mps.playfab.com_gameserverbuilds.yaml
+++ b/pkg/operator/config/crd/bases/mps.playfab.com_gameserverbuilds.yaml
@@ -433,9 +433,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -495,7 +492,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -604,9 +601,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -663,7 +658,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -774,9 +769,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -836,7 +828,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -945,9 +937,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -1004,7 +994,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -1037,7 +1027,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -1053,8 +1043,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -1233,7 +1223,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -1481,7 +1471,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -1693,7 +1683,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2071,7 +2061,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2396,13 +2386,13 @@ spec:
                             feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              description: 'Arguments to the entrypoint. The image''s
+                                CMD is used if this is not provided. Variable references
+                                $(VAR_NAME) are expanded using the container''s environment.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
                                 the string literal "$(VAR_NAME)". Escaped references
                                 will never be expanded, regardless of whether the
                                 variable exists or not. Cannot be updated. More info:
@@ -2412,10 +2402,10 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
+                                a shell. The image''s ENTRYPOINT is used if this is
+                                not provided. Variable references $(VAR_NAME) are
+                                expanded using the container''s environment. If a
+                                variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
                                 to a single $, which allows for escaping the $(VAR_NAME)
                                 syntax: i.e. "$$(VAR_NAME)" will produce the string
@@ -2592,7 +2582,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never,
@@ -2834,7 +2824,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -3037,7 +3027,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -3408,7 +3398,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -3710,8 +3700,7 @@ spec:
                           to secrets in the same namespace to use for pulling any
                           of the images used by this PodSpec. If specified, these
                           secrets will be passed to individual puller implementations
-                          for them to use. For example, in the case of docker, only
-                          DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information
                             to let you locate the referenced object inside the same
@@ -3743,7 +3732,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -3759,8 +3748,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -3939,7 +3928,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -4187,7 +4176,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -4399,7 +4388,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -4777,7 +4766,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -5057,7 +5046,7 @@ spec:
                           - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
                           - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
                           - spec.containers[*].securityContext.runAsGroup This is
-                          an alpha field and requires the IdentifyPodOS feature"
+                          a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system.
@@ -5087,15 +5076,12 @@ spec:
                           is configured and selected in the PodSpec, Overhead will
                           be set to the value defined in the corresponding RuntimeClass,
                           otherwise it will remain unset and treated as zero. More
-                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
-                          This field is beta-level as of Kubernetes v1.18, and is
-                          only honored by servers that enable the PodOverhead feature.'
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
                         description: PreemptionPolicy is the Policy for preempting
                           pods with lower priority. One of Never, PreemptLowerPriority.
-                          Defaults to PreemptLowerPriority if unset. This field is
-                          beta-level, gated by the NonPreemptingPriority feature-gate.
+                          Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components
@@ -5144,8 +5130,7 @@ spec:
                           the pod will not be run. If unset or empty, the "legacy"
                           RuntimeClass will be used, which is an implicit class with
                           an empty definition that uses the default runtime handler.
-                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
-                          This is a beta feature as of Kubernetes v1.14.'
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified
@@ -5483,17 +5468,48 @@ spec:
                                 pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                 it is the maximum permitted difference between the
                                 number of matching pods in the target topology and
-                                the global minimum. For example, in a 3-zone cluster,
-                                MaxSkew is set to 1, and pods with the same labelSelector
-                                spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                                - if MaxSkew is 1, incoming pod can only be scheduled
-                                to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                                would make the ActualSkew(2-0) on zone1(zone2) violate
-                                MaxSkew(1). - if MaxSkew is 2, incoming pod can be
-                                scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                 it is used to give higher precedence to topologies
                                 that satisfy it. It''s a required field. Default value
                                 is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number
+                                of eligible domains. When the number of eligible domains
+                                with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats \"global minimum\" as 0,
+                                and then the calculation of Skew is performed. And
+                                when the number of eligible domains with matching
+                                topology keys equals or greater than minDomains, this
+                                value has no effect on scheduling. As a result, when
+                                the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to
+                                those domains. If value is nil, the constraint behaves
+                                as if MinDomains is equal to 1. Valid values are integers
+                                greater than 0. When value is not nil, WhenUnsatisfiable
+                                must be DoNotSchedule. \n For example, in a 3-zone
+                                cluster, MaxSkew is set to 2, MinDomains is set to
+                                5 and pods with the same labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains),
+                                so \"global minimum\" is treated as 0. In this situation,
+                                new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod
+                                is scheduled to any of the three zones, it will violate
+                                MaxSkew. \n This is an alpha field and requires enabling
+                                MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
@@ -5501,8 +5517,14 @@ spec:
                                 Nodes that have a label with this key and identical
                                 values are considered to be in the same topology.
                                 We consider each <key, value> as a "bucket", and try
-                                to put balanced number of pods into each bucket. It's
-                                a required field.
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes match the node selector. e.g. If TopologyKey
+                                is "kubernetes.io/hostname", each Node is a domain
+                                of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                                each zone is a domain of that topology. It's a required
+                                field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal
@@ -5542,123 +5564,128 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS
+                              description: 'awsElasticBlockStore represents an AWS
                                 Disk resource that is attached to a kubelet''s host
                                 machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty).'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the
-                                    ReadOnly property in VolumeMounts to "true". If
-                                    omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource
-                                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk
+                              description: azureDisk represents an Azure Data Disk
                                 mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only,
-                                    Read Write.'
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob
-                                    storage
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob
-                                    disks per storage account  Dedicated: single blob
-                                    disk per storage account  Managed: azure managed
-                                    data disk (only in managed availability set).
-                                    defaults to shared'
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service
+                              description: azureFile represents an Azure File Service
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure
-                                    Storage Account Name and Key
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the
+                              description: cephFS represents a Ceph FS mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection
-                                    of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root,
-                                    rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to
-                                    key ring for User, default is /etc/ceph/user.secret
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
                                     More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the authentication secret for User, default is
-                                    empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -5668,31 +5695,32 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name,
-                                    default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached
+                              description: 'cinder represents a cinder volume attached
                                 and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
+                                  description: 'readOnly defaults to false (read/write).
                                     ReadOnly here will force the ReadOnly setting
                                     in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object
-                                    containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -5702,32 +5730,32 @@ spec:
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume
+                                  description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should
+                              description: configMap represents a configMap that should
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
                                     will be projected into the volume as a file whose
                                     name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
@@ -5742,26 +5770,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -5774,28 +5804,28 @@ spec:
                                     uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents
+                              description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver
+                                  description: driver is the name of the CSI driver
                                     that handles this volume. Consult with your admin
                                     for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4",
-                                    "xfs", "ntfs". If not provided, the empty value
-                                    is passed to the associated CSI driver which will
-                                    determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference
+                                  description: nodePublishSecretRef is a reference
                                     to the secret object containing sensitive information
                                     to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
@@ -5812,13 +5842,13 @@ spec:
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration
+                                  description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific
+                                  description: volumeAttributes stores driver-specific
                                     properties that are passed to the CSI driver.
                                     Consult your driver's documentation for supported
                                     values.
@@ -5827,7 +5857,7 @@ spec:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about
+                              description: downwardAPI represents downward API about
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
@@ -5920,32 +5950,33 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory
+                              description: 'emptyDir represents a temporary directory
                                 that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should
-                                    back this directory. The default is "" which means
-                                    to use the node''s default medium. Must be an
-                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required
-                                    for this EmptyDir volume. The size limit is also
-                                    applicable for memory medium. The maximum usage
-                                    on memory medium EmptyDir would be the minimum
-                                    value between the SizeLimit specified here and
-                                    the sum of memory limits of all containers in
-                                    a pod. The default is nil which means that the
-                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is
+                              description: "ephemeral represents a volume that is
                                 handled by a cluster storage driver. The volume's
                                 lifecycle is tied to the pod that defines it - it
                                 will be created before the pod starts, and deleted
@@ -6021,15 +6052,15 @@ spec:
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired
+                                          description: 'accessModes contains the desired
                                             access modes the volume should have. More
                                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to
-                                            specify either: * An existing VolumeSnapshot
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
                                             object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
                                             If the provisioner or an external controller
@@ -6062,10 +6093,10 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from
-                                            which to populate the volume with data,
-                                            if a non-empty volume is desired. This
-                                            may be any local object from a non-empty
+                                          description: 'dataSourceRef specifies the
+                                            object from which to populate the volume
+                                            with data, if a non-empty volume is desired.
+                                            This may be any local object from a non-empty
                                             API group (non core object) or a PersistentVolumeClaim
                                             object. When this field is specified,
                                             volume binding will only succeed if the
@@ -6088,9 +6119,8 @@ spec:
                                             values (dropping them), DataSourceRef
                                             preserves all values, and generates an
                                             error if a disallowed value is specified.
-                                            (Alpha) Using this field requires the
-                                            AnyVolumeDataSource feature gate to be
-                                            enabled.'
+                                            (Beta) Using this field requires the AnyVolumeDataSource
+                                            feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for
@@ -6113,7 +6143,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum
+                                          description: 'resources represents the minimum
                                             resources the volume should have. If RecoverVolumeExpansionFailure
                                             feature is enabled users are allowed to
                                             specify resource requirements that are
@@ -6150,8 +6180,8 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes
-                                            to consider for binding.
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -6205,8 +6235,9 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required
-                                            by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type
@@ -6215,7 +6246,7 @@ spec:
                                             in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference
+                                          description: volumeName is the binding reference
                                             to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
@@ -6224,74 +6255,75 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource
+                              description: fc represents a Fibre Channel resource
                                 that is attached to a kubelet's host machine and then
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified. TODO: how
                                     do we prevent errors in the filesystem from compromising
                                     the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names
-                                    (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers
-                                    (wwids) Either wwids or combination of targetWWNs
-                                    and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume
+                              description: flexVolume represents a generic volume
                                 resource that is provisioned/attached using an exec
                                 based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to
+                                  description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". The default
-                                    filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if
-                                    any.'
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the secret object containing sensitive information
-                                    to pass to the plugin scripts. This may be empty
-                                    if no secret object is specified. If the secret
-                                    object contains more than one secret, all secrets
-                                    are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -6304,28 +6336,28 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached
+                              description: flocker represents a Flocker volume attached
                                 to a kubelet's host machine. This depends on the Flocker
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata
-                                    -> name on the dataset for Flocker should be considered
-                                    as deprecated
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique
-                                    identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk
+                              description: 'gcePersistentDisk represents a GCE Disk
                                 resource that is attached to a kubelet''s host machine
                                 and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
                                     type is supported by the host operating system.
                                     Examples: "ext4", "xfs", "ntfs". Implicitly inferred
                                     to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
@@ -6333,21 +6365,22 @@ spec:
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in
-                                    GCE. Used to identify the disk in GCE. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
@@ -6355,7 +6388,7 @@ spec:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at
+                              description: 'gitRepo represents a git repository at
                                 a particular revision. DEPRECATED: GitRepo is deprecated.
                                 To provision a container with a git repo, mount an
                                 EmptyDir into an InitContainer that clones the repo
@@ -6363,37 +6396,38 @@ spec:
                                 container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain
-                                    or start with '..'.  If '.' is supplied, the volume
-                                    directory will be the git repository.  Otherwise,
-                                    if specified, the volume will contain the git
-                                    repository in the subdirectory with the given
-                                    name.
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount
+                              description: 'glusterfs represents a Glusterfs mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name
-                                    that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path.
+                                  description: 'path is the Glusterfs volume path.
                                     More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs
+                                  description: 'readOnly here will force the Glusterfs
                                     volume to be mounted with read-only permissions.
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
@@ -6402,7 +6436,7 @@ spec:
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file
+                              description: 'hostPath represents a pre-existing file
                                 or directory on the host machine that is directly
                                 exposed to the container. This is generally used for
                                 system agents or other privileged things that are
@@ -6413,71 +6447,73 @@ spec:
                                 directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host.
+                                  description: 'path of the directory on the host.
                                     If the path is a symlink, it will follow the link
                                     to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults
+                                  description: 'type for HostPath Volume Defaults
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource
+                              description: 'iscsi represents an ISCSI Disk resource
                                 that is attached to a kubelet''s host machine and
                                 then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP
-                                    authentication
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP
-                                    authentication
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName
-                                    is specified with iscsiInterface simultaneously,
-                                    new iSCSI interface <target portal>:<volume name>
-                                    will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI
-                                    transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal
-                                    is either an IP or ip_addr:port if the port is
-                                    other than default (typically TCP ports 860 and
-                                    3260).
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly
+                                  description: readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator
-                                    authentication
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -6487,9 +6523,10 @@ spec:
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is
-                                    either an IP or ip_addr:port if the port is other
-                                    than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -6497,24 +6534,24 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and
-                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host
+                              description: 'nfs represents an NFS mount on the host
                                 that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server.
+                                  description: 'path that is exported by the NFS server.
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export
+                                  description: 'readOnly here will force the NFS export
                                     to be mounted with read-only permissions. Defaults
                                     to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address
+                                  description: 'server is the hostname or IP address
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
@@ -6522,132 +6559,133 @@ spec:
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents
+                              description: 'persistentVolumeClaimVolumeSource represents
                                 a reference to a PersistentVolumeClaim in the same
                                 namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  description: 'claimName is the name of a PersistentVolumeClaim
                                     in the same namespace as the pod using this volume.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in
-                                    VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController
+                              description: photonPersistentDisk represents a PhotonController
                                 persistent disk attached and mounted on kubelets host
                                 machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller
-                                    persistent disk
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume
+                              description: portworxVolume represents a portworx volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type
+                                  description: fSType represents the filesystem type
                                     to mount Must be a filesystem type supported by
                                     the host operating system. Ex. "ext4", "xfs".
                                     Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx
+                                  description: volumeID uniquely identifies a Portworx
                                     volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets,
-                                configmaps, and downward API
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on
-                                    created files by default. Must be an octal value
-                                    between 0000 and 0777 or a decimal value between
-                                    0 and 511. YAML accepts both octal and decimal
-                                    values, JSON requires decimal values for mode
-                                    bits. Directories within the path are not affected
-                                    by this setting. This might be in conflict with
-                                    other options that affect the file mode, like
-                                    fsGroup, and the result can be other mode bits
-                                    set.
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap
-                                          data to project
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              ConfigMap will be projected into the
-                                              volume as a file whose name is the key
-                                              and content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the ConfigMap,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -6662,13 +6700,13 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its keys must be defined
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI
-                                          data to project
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume
@@ -6758,53 +6796,53 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret
-                                          data to project
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              Secret will be projected into the volume
-                                              as a file whose name is the key and
-                                              content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the Secret,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -6819,16 +6857,16 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken
-                                          data to project
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended
+                                            description: audience is the intended
                                               audience of the token. A recipient of
                                               a token must identify itself with an
                                               identifier specified in the audience
@@ -6837,7 +6875,7 @@ spec:
                                               the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the
+                                            description: expirationSeconds is the
                                               requested duration of validity of the
                                               service account token. As the token
                                               approaches expiration, the kubelet volume
@@ -6851,7 +6889,7 @@ spec:
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative
+                                            description: path is the path relative
                                               to the mount point of the file to project
                                               the token into.
                                             type: string
@@ -6862,36 +6900,36 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the
+                              description: quobyte represents a Quobyte mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default
+                                  description: group to map volume access to Default
                                     is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte
+                                  description: readOnly here will force the Quobyte
                                     volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple
+                                  description: registry represents a single or multiple
                                     Quobyte Registry services specified as a string
                                     as host:port pair (multiple entries are separated
                                     with commas) which acts as the central registry
                                     for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume
+                                  description: tenant owning the given Quobyte volume
                                     in the Backend Used with dynamically provisioned
                                     Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults
+                                  description: user to map volume access to Defaults
                                     to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references
+                                  description: volume is a string that references
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
@@ -6899,44 +6937,46 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount
+                              description: 'rbd represents a Rados Block Device mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for
+                                  description: 'keyring is the path to key ring for
                                     RBDUser. Default is /etc/ceph/keyring. More info:
                                     https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication
+                                  description: 'secretRef is name of the authentication
                                     secret for RBDUser. If provided overrides keyring.
                                     Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
@@ -6948,37 +6988,38 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent
+                              description: scaleIO represents a ScaleIO persistent
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Default is
-                                    "xfs".
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API
-                                    Gateway.
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection
-                                    Domain for the configured storage.
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret
+                                  description: secretRef references to the secret
                                     for ScaleIO user and other sensitive information.
                                     If this is not provided, Login operation will
                                     fail.
@@ -6991,26 +7032,26 @@ spec:
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication
-                                    with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a
-                                    volume should be ThickProvisioned or ThinProvisioned.
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated
-                                    with the protection domain.
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured
-                                    in ScaleIO.
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created
-                                    in the ScaleIO system that is associated with
-                                    this volume source.
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -7018,27 +7059,27 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should
+                              description: 'secret represents a secret that should
                                 populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
                                     paths, and unlisted keys will not be present.
                                     If a key is specified which is not present in
@@ -7051,26 +7092,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -7078,30 +7121,31 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys
-                                    must be defined
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace
-                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume
+                              description: storageOS represents a StorageOS volume
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use
+                                  description: secretRef specifies the secret to use
                                     for obtaining the StorageOS API credentials.  If
                                     not specified, default values will be attempted.
                                   properties:
@@ -7113,12 +7157,12 @@ spec:
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name
+                                  description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
                                     unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope
+                                  description: volumeNamespace specifies the scope
                                     of the volume within StorageOS.  If no namespace
                                     is specified then the Pod's namespace will be
                                     used.  This allows the Kubernetes name scoping
@@ -7130,26 +7174,27 @@ spec:
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume
+                              description: vsphereVolume represents a vSphere volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile name.
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume
-                                    vmdk
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath

--- a/pkg/operator/config/crd/bases/mps.playfab.com_gameservers.yaml
+++ b/pkg/operator/config/crd/bases/mps.playfab.com_gameservers.yaml
@@ -423,9 +423,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -485,7 +482,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -594,9 +591,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -653,7 +648,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -764,9 +759,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -826,7 +818,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -935,9 +927,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -994,7 +984,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -1027,7 +1017,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -1043,8 +1033,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -1223,7 +1213,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -1471,7 +1461,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -1683,7 +1673,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2061,7 +2051,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2386,13 +2376,13 @@ spec:
                             feature gate."
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
-                                image''s CMD is used if this is not provided. Variable
-                                references $(VAR_NAME) are expanded using the container''s
-                                environment. If a variable cannot be resolved, the
-                                reference in the input string will be unchanged. Double
-                                $$ are reduced to a single $, which allows for escaping
-                                the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              description: 'Arguments to the entrypoint. The image''s
+                                CMD is used if this is not provided. Variable references
+                                $(VAR_NAME) are expanded using the container''s environment.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. Double $$ are
+                                reduced to a single $, which allows for escaping the
+                                $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
                                 the string literal "$(VAR_NAME)". Escaped references
                                 will never be expanded, regardless of whether the
                                 variable exists or not. Cannot be updated. More info:
@@ -2402,10 +2392,10 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
-                                are expanded using the container''s environment. If
-                                a variable cannot be resolved, the reference in the
+                                a shell. The image''s ENTRYPOINT is used if this is
+                                not provided. Variable references $(VAR_NAME) are
+                                expanded using the container''s environment. If a
+                                variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
                                 to a single $, which allows for escaping the $(VAR_NAME)
                                 syntax: i.e. "$$(VAR_NAME)" will produce the string
@@ -2582,7 +2572,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
                               description: 'Image pull policy. One of Always, Never,
@@ -2824,7 +2814,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -3027,7 +3017,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -3398,7 +3388,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -3700,8 +3690,7 @@ spec:
                           to secrets in the same namespace to use for pulling any
                           of the images used by this PodSpec. If specified, these
                           secrets will be passed to individual puller implementations
-                          for them to use. For example, in the case of docker, only
-                          DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
                           description: LocalObjectReference contains enough information
                             to let you locate the referenced object inside the same
@@ -3733,7 +3722,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -3749,8 +3738,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -3929,7 +3918,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -4177,7 +4166,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -4389,7 +4378,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -4767,7 +4756,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -5047,7 +5036,7 @@ spec:
                           - spec.containers[*].securityContext.privileged - spec.containers[*].securityContext.allowPrivilegeEscalation
                           - spec.containers[*].securityContext.procMount - spec.containers[*].securityContext.runAsUser
                           - spec.containers[*].securityContext.runAsGroup This is
-                          an alpha field and requires the IdentifyPodOS feature"
+                          a beta field and requires the IdentifyPodOS feature"
                         properties:
                           name:
                             description: 'Name is the name of the operating system.
@@ -5077,15 +5066,12 @@ spec:
                           is configured and selected in the PodSpec, Overhead will
                           be set to the value defined in the corresponding RuntimeClass,
                           otherwise it will remain unset and treated as zero. More
-                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
-                          This field is beta-level as of Kubernetes v1.18, and is
-                          only honored by servers that enable the PodOverhead feature.'
+                          info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md'
                         type: object
                       preemptionPolicy:
                         description: PreemptionPolicy is the Policy for preempting
                           pods with lower priority. One of Never, PreemptLowerPriority.
-                          Defaults to PreemptLowerPriority if unset. This field is
-                          beta-level, gated by the NonPreemptingPriority feature-gate.
+                          Defaults to PreemptLowerPriority if unset.
                         type: string
                       priority:
                         description: The priority value. Various system components
@@ -5134,8 +5120,7 @@ spec:
                           the pod will not be run. If unset or empty, the "legacy"
                           RuntimeClass will be used, which is an implicit class with
                           an empty definition that uses the default runtime handler.
-                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
-                          This is a beta feature as of Kubernetes v1.14.'
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class'
                         type: string
                       schedulerName:
                         description: If specified, the pod will be dispatched by specified
@@ -5473,17 +5458,48 @@ spec:
                                 pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                 it is the maximum permitted difference between the
                                 number of matching pods in the target topology and
-                                the global minimum. For example, in a 3-zone cluster,
-                                MaxSkew is set to 1, and pods with the same labelSelector
-                                spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                                - if MaxSkew is 1, incoming pod can only be scheduled
-                                to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                                would make the ActualSkew(2-0) on zone1(zone2) violate
-                                MaxSkew(1). - if MaxSkew is 2, incoming pod can be
-                                scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                 it is used to give higher precedence to topologies
                                 that satisfy it. It''s a required field. Default value
                                 is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number
+                                of eligible domains. When the number of eligible domains
+                                with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats \"global minimum\" as 0,
+                                and then the calculation of Skew is performed. And
+                                when the number of eligible domains with matching
+                                topology keys equals or greater than minDomains, this
+                                value has no effect on scheduling. As a result, when
+                                the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to
+                                those domains. If value is nil, the constraint behaves
+                                as if MinDomains is equal to 1. Valid values are integers
+                                greater than 0. When value is not nil, WhenUnsatisfiable
+                                must be DoNotSchedule. \n For example, in a 3-zone
+                                cluster, MaxSkew is set to 2, MinDomains is set to
+                                5 and pods with the same labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains),
+                                so \"global minimum\" is treated as 0. In this situation,
+                                new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod
+                                is scheduled to any of the three zones, it will violate
+                                MaxSkew. \n This is an alpha field and requires enabling
+                                MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
@@ -5491,8 +5507,14 @@ spec:
                                 Nodes that have a label with this key and identical
                                 values are considered to be in the same topology.
                                 We consider each <key, value> as a "bucket", and try
-                                to put balanced number of pods into each bucket. It's
-                                a required field.
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes match the node selector. e.g. If TopologyKey
+                                is "kubernetes.io/hostname", each Node is a domain
+                                of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                                each zone is a domain of that topology. It's a required
+                                field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal
@@ -5532,123 +5554,128 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS
+                              description: 'awsElasticBlockStore represents an AWS
                                 Disk resource that is attached to a kubelet''s host
                                 machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty).'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the
-                                    ReadOnly property in VolumeMounts to "true". If
-                                    omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource
-                                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk
+                              description: azureDisk represents an Azure Data Disk
                                 mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only,
-                                    Read Write.'
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob
-                                    storage
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob
-                                    disks per storage account  Dedicated: single blob
-                                    disk per storage account  Managed: azure managed
-                                    data disk (only in managed availability set).
-                                    defaults to shared'
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service
+                              description: azureFile represents an Azure File Service
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure
-                                    Storage Account Name and Key
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the
+                              description: cephFS represents a Ceph FS mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection
-                                    of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root,
-                                    rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to
-                                    key ring for User, default is /etc/ceph/user.secret
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
                                     More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the authentication secret for User, default is
-                                    empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -5658,31 +5685,32 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name,
-                                    default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached
+                              description: 'cinder represents a cinder volume attached
                                 and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
+                                  description: 'readOnly defaults to false (read/write).
                                     ReadOnly here will force the ReadOnly setting
                                     in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object
-                                    containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -5692,32 +5720,32 @@ spec:
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume
+                                  description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should
+                              description: configMap represents a configMap that should
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
                                     will be projected into the volume as a file whose
                                     name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
@@ -5732,26 +5760,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -5764,28 +5794,28 @@ spec:
                                     uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents
+                              description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver
+                                  description: driver is the name of the CSI driver
                                     that handles this volume. Consult with your admin
                                     for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4",
-                                    "xfs", "ntfs". If not provided, the empty value
-                                    is passed to the associated CSI driver which will
-                                    determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference
+                                  description: nodePublishSecretRef is a reference
                                     to the secret object containing sensitive information
                                     to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
@@ -5802,13 +5832,13 @@ spec:
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration
+                                  description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific
+                                  description: volumeAttributes stores driver-specific
                                     properties that are passed to the CSI driver.
                                     Consult your driver's documentation for supported
                                     values.
@@ -5817,7 +5847,7 @@ spec:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about
+                              description: downwardAPI represents downward API about
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
@@ -5910,32 +5940,33 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory
+                              description: 'emptyDir represents a temporary directory
                                 that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should
-                                    back this directory. The default is "" which means
-                                    to use the node''s default medium. Must be an
-                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required
-                                    for this EmptyDir volume. The size limit is also
-                                    applicable for memory medium. The maximum usage
-                                    on memory medium EmptyDir would be the minimum
-                                    value between the SizeLimit specified here and
-                                    the sum of memory limits of all containers in
-                                    a pod. The default is nil which means that the
-                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is
+                              description: "ephemeral represents a volume that is
                                 handled by a cluster storage driver. The volume's
                                 lifecycle is tied to the pod that defines it - it
                                 will be created before the pod starts, and deleted
@@ -6011,15 +6042,15 @@ spec:
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired
+                                          description: 'accessModes contains the desired
                                             access modes the volume should have. More
                                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to
-                                            specify either: * An existing VolumeSnapshot
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
                                             object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
                                             If the provisioner or an external controller
@@ -6052,10 +6083,10 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from
-                                            which to populate the volume with data,
-                                            if a non-empty volume is desired. This
-                                            may be any local object from a non-empty
+                                          description: 'dataSourceRef specifies the
+                                            object from which to populate the volume
+                                            with data, if a non-empty volume is desired.
+                                            This may be any local object from a non-empty
                                             API group (non core object) or a PersistentVolumeClaim
                                             object. When this field is specified,
                                             volume binding will only succeed if the
@@ -6078,9 +6109,8 @@ spec:
                                             values (dropping them), DataSourceRef
                                             preserves all values, and generates an
                                             error if a disallowed value is specified.
-                                            (Alpha) Using this field requires the
-                                            AnyVolumeDataSource feature gate to be
-                                            enabled.'
+                                            (Beta) Using this field requires the AnyVolumeDataSource
+                                            feature gate to be enabled.'
                                           properties:
                                             apiGroup:
                                               description: APIGroup is the group for
@@ -6103,7 +6133,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum
+                                          description: 'resources represents the minimum
                                             resources the volume should have. If RecoverVolumeExpansionFailure
                                             feature is enabled users are allowed to
                                             specify resource requirements that are
@@ -6140,8 +6170,8 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes
-                                            to consider for binding.
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -6195,8 +6225,9 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required
-                                            by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type
@@ -6205,7 +6236,7 @@ spec:
                                             in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference
+                                          description: volumeName is the binding reference
                                             to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
@@ -6214,74 +6245,75 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource
+                              description: fc represents a Fibre Channel resource
                                 that is attached to a kubelet's host machine and then
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified. TODO: how
                                     do we prevent errors in the filesystem from compromising
                                     the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names
-                                    (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers
-                                    (wwids) Either wwids or combination of targetWWNs
-                                    and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume
+                              description: flexVolume represents a generic volume
                                 resource that is provisioned/attached using an exec
                                 based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to
+                                  description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". The default
-                                    filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if
-                                    any.'
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the secret object containing sensitive information
-                                    to pass to the plugin scripts. This may be empty
-                                    if no secret object is specified. If the secret
-                                    object contains more than one secret, all secrets
-                                    are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -6294,28 +6326,28 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached
+                              description: flocker represents a Flocker volume attached
                                 to a kubelet's host machine. This depends on the Flocker
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata
-                                    -> name on the dataset for Flocker should be considered
-                                    as deprecated
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique
-                                    identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk
+                              description: 'gcePersistentDisk represents a GCE Disk
                                 resource that is attached to a kubelet''s host machine
                                 and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
                                     type is supported by the host operating system.
                                     Examples: "ext4", "xfs", "ntfs". Implicitly inferred
                                     to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
@@ -6323,21 +6355,22 @@ spec:
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in
-                                    GCE. Used to identify the disk in GCE. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
@@ -6345,7 +6378,7 @@ spec:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at
+                              description: 'gitRepo represents a git repository at
                                 a particular revision. DEPRECATED: GitRepo is deprecated.
                                 To provision a container with a git repo, mount an
                                 EmptyDir into an InitContainer that clones the repo
@@ -6353,37 +6386,38 @@ spec:
                                 container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain
-                                    or start with '..'.  If '.' is supplied, the volume
-                                    directory will be the git repository.  Otherwise,
-                                    if specified, the volume will contain the git
-                                    repository in the subdirectory with the given
-                                    name.
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount
+                              description: 'glusterfs represents a Glusterfs mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name
-                                    that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path.
+                                  description: 'path is the Glusterfs volume path.
                                     More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs
+                                  description: 'readOnly here will force the Glusterfs
                                     volume to be mounted with read-only permissions.
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
@@ -6392,7 +6426,7 @@ spec:
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file
+                              description: 'hostPath represents a pre-existing file
                                 or directory on the host machine that is directly
                                 exposed to the container. This is generally used for
                                 system agents or other privileged things that are
@@ -6403,71 +6437,73 @@ spec:
                                 directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host.
+                                  description: 'path of the directory on the host.
                                     If the path is a symlink, it will follow the link
                                     to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults
+                                  description: 'type for HostPath Volume Defaults
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource
+                              description: 'iscsi represents an ISCSI Disk resource
                                 that is attached to a kubelet''s host machine and
                                 then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP
-                                    authentication
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP
-                                    authentication
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName
-                                    is specified with iscsiInterface simultaneously,
-                                    new iSCSI interface <target portal>:<volume name>
-                                    will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI
-                                    transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal
-                                    is either an IP or ip_addr:port if the port is
-                                    other than default (typically TCP ports 860 and
-                                    3260).
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly
+                                  description: readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator
-                                    authentication
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -6477,9 +6513,10 @@ spec:
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is
-                                    either an IP or ip_addr:port if the port is other
-                                    than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -6487,24 +6524,24 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and
-                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host
+                              description: 'nfs represents an NFS mount on the host
                                 that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server.
+                                  description: 'path that is exported by the NFS server.
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export
+                                  description: 'readOnly here will force the NFS export
                                     to be mounted with read-only permissions. Defaults
                                     to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address
+                                  description: 'server is the hostname or IP address
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
@@ -6512,132 +6549,133 @@ spec:
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents
+                              description: 'persistentVolumeClaimVolumeSource represents
                                 a reference to a PersistentVolumeClaim in the same
                                 namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  description: 'claimName is the name of a PersistentVolumeClaim
                                     in the same namespace as the pod using this volume.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in
-                                    VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController
+                              description: photonPersistentDisk represents a PhotonController
                                 persistent disk attached and mounted on kubelets host
                                 machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller
-                                    persistent disk
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume
+                              description: portworxVolume represents a portworx volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type
+                                  description: fSType represents the filesystem type
                                     to mount Must be a filesystem type supported by
                                     the host operating system. Ex. "ext4", "xfs".
                                     Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx
+                                  description: volumeID uniquely identifies a Portworx
                                     volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets,
-                                configmaps, and downward API
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on
-                                    created files by default. Must be an octal value
-                                    between 0000 and 0777 or a decimal value between
-                                    0 and 511. YAML accepts both octal and decimal
-                                    values, JSON requires decimal values for mode
-                                    bits. Directories within the path are not affected
-                                    by this setting. This might be in conflict with
-                                    other options that affect the file mode, like
-                                    fsGroup, and the result can be other mode bits
-                                    set.
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap
-                                          data to project
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              ConfigMap will be projected into the
-                                              volume as a file whose name is the key
-                                              and content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the ConfigMap,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -6652,13 +6690,13 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its keys must be defined
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI
-                                          data to project
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume
@@ -6748,53 +6786,53 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret
-                                          data to project
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              Secret will be projected into the volume
-                                              as a file whose name is the key and
-                                              content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the Secret,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -6809,16 +6847,16 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken
-                                          data to project
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended
+                                            description: audience is the intended
                                               audience of the token. A recipient of
                                               a token must identify itself with an
                                               identifier specified in the audience
@@ -6827,7 +6865,7 @@ spec:
                                               the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the
+                                            description: expirationSeconds is the
                                               requested duration of validity of the
                                               service account token. As the token
                                               approaches expiration, the kubelet volume
@@ -6841,7 +6879,7 @@ spec:
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative
+                                            description: path is the path relative
                                               to the mount point of the file to project
                                               the token into.
                                             type: string
@@ -6852,36 +6890,36 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the
+                              description: quobyte represents a Quobyte mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default
+                                  description: group to map volume access to Default
                                     is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte
+                                  description: readOnly here will force the Quobyte
                                     volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple
+                                  description: registry represents a single or multiple
                                     Quobyte Registry services specified as a string
                                     as host:port pair (multiple entries are separated
                                     with commas) which acts as the central registry
                                     for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume
+                                  description: tenant owning the given Quobyte volume
                                     in the Backend Used with dynamically provisioned
                                     Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults
+                                  description: user to map volume access to Defaults
                                     to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references
+                                  description: volume is a string that references
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
@@ -6889,44 +6927,46 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount
+                              description: 'rbd represents a Rados Block Device mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for
+                                  description: 'keyring is the path to key ring for
                                     RBDUser. Default is /etc/ceph/keyring. More info:
                                     https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication
+                                  description: 'secretRef is name of the authentication
                                     secret for RBDUser. If provided overrides keyring.
                                     Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
@@ -6938,37 +6978,38 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent
+                              description: scaleIO represents a ScaleIO persistent
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Default is
-                                    "xfs".
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API
-                                    Gateway.
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection
-                                    Domain for the configured storage.
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret
+                                  description: secretRef references to the secret
                                     for ScaleIO user and other sensitive information.
                                     If this is not provided, Login operation will
                                     fail.
@@ -6981,26 +7022,26 @@ spec:
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication
-                                    with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a
-                                    volume should be ThickProvisioned or ThinProvisioned.
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated
-                                    with the protection domain.
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured
-                                    in ScaleIO.
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created
-                                    in the ScaleIO system that is associated with
-                                    this volume source.
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -7008,27 +7049,27 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should
+                              description: 'secret represents a secret that should
                                 populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
                                     paths, and unlisted keys will not be present.
                                     If a key is specified which is not present in
@@ -7041,26 +7082,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -7068,30 +7111,31 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys
-                                    must be defined
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace
-                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume
+                              description: storageOS represents a StorageOS volume
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use
+                                  description: secretRef specifies the secret to use
                                     for obtaining the StorageOS API credentials.  If
                                     not specified, default values will be attempted.
                                   properties:
@@ -7103,12 +7147,12 @@ spec:
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name
+                                  description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
                                     unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope
+                                  description: volumeNamespace specifies the scope
                                     of the volume within StorageOS.  If no namespace
                                     is specified then the Pod's namespace will be
                                     used.  This allows the Kubernetes name scoping
@@ -7120,26 +7164,27 @@ spec:
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume
+                              description: vsphereVolume represents a vSphere volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile name.
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume
-                                    vmdk
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath

--- a/pkg/operator/controllers/gameserver_controller.go
+++ b/pkg/operator/controllers/gameserver_controller.go
@@ -175,7 +175,7 @@ func (r *GameServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// if a game server is active, there are players present.
 	// When using the cluster autoscaler, an annotation will be added
 	// to prevent the node from being scaled down.
-	r.Recorder.Eventf(&gs, corev1.EventTypeNormal, "Update", "Gameserver %s state is %s", gs.Name, gs.Status.State)
+	r.Recorder.Eventf(&gs, corev1.EventTypeNormal, "Update", "Gameserver %s state is %s, health is %s", gs.Name, gs.Status.State, gs.Status.Health)
 	err := r.addSafeToEvictAnnotationIfNecessary(ctx, &gs, &pod)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/pkg/operator/controllers/metrics.go
+++ b/pkg/operator/controllers/metrics.go
@@ -36,7 +36,15 @@ var (
 		prometheus.CounterOpts{
 			Namespace: "thundernetes",
 			Name:      "gameservers_crashed_total",
-			Help:      "Number of GameServers sessions crashed",
+			Help:      "Number of GameServers crashed",
+		},
+		[]string{"BuildName"},
+	)
+	GameServersUnhealthyCounter = registry.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "thundernetes",
+			Name:      "gameservers_unhealthy_total",
+			Help:      "Number of GameServers marked as Unhealthy",
 		},
 		[]string{"BuildName"},
 	)

--- a/pkg/operator/controllers/test_utils_test.go
+++ b/pkg/operator/controllers/test_utils_test.go
@@ -171,7 +171,7 @@ func testUpdateInitializingGameServersToStandingBy(ctx context.Context, buildID 
 			gs := getGameServer(ctx, gameServer.Name) // getting the latest updated GameServer object
 			patch := client.MergeFrom(gs.DeepCopy())
 			gs.Status.State = mpsv1alpha1.GameServerStateStandingBy
-			gs.Status.Health = mpsv1alpha1.Healthy
+			gs.Status.Health = mpsv1alpha1.GameServerHealthy
 			err = testk8sClient.Status().Patch(ctx, &gs, patch)
 			Expect(err).ToNot(HaveOccurred())
 		}


### PR DESCRIPTION
Fixes #56 

This PR modifies the GameServerBuild controller to delete a GameServer when its status becomes Unhealthy.

As a side effect, we expect it to fix #256 and #257 since Unhealthy GameServers won't exist in the cluster any more so:

i) they won't be taken into account when scaling
ii) NodeAgent will get a notification about their deletion so it will not repeatedly try to mark them as Unhealthy

The change in the YAML files is probably due to the new C-R version that was merged in a different PR.