### PR TITLE
fixing NodeAgent tests

### DIFF
--- a/cmd/nodeagent/nodeagentmanager.go
+++ b/cmd/nodeagent/nodeagentmanager.go
@@ -24,15 +24,15 @@ import (
 )
 
 const (
-	GameServerName      = "GameServerName"
-	GameServerNamespace = "GameServerNamespace"
-	defaultTimeout      = 4
-	LabelNodeName       = "NodeName"
-	ErrBuildIDNotExists = "buildID does not exist"
-	ErrStateNotExists   = "state does not exist"
-	ErrHealthNotExists  = "health does not exist"
-	unhealthyStatus     = "Unhealthy"
-	healthyStatus       = "Healthy"
+	GameServerName        = "GameServerName"
+	GameServerNamespace   = "GameServerNamespace"
+	defaultTimeout        = 4
+	LabelNodeName         = "NodeName"
+	ErrBuildNameNotExists = "build name does not exist"
+	ErrStateNotExists     = "state does not exist"
+	ErrHealthNotExists    = "health does not exist"
+	unhealthyStatus       = "Unhealthy"
+	healthyStatus         = "Healthy"
 )
 
 // HeartbeatState is a status of a gameserver, it represents if it has sent heartbeats

--- a/cmd/nodeagent/nodeagentmanager_test.go
+++ b/cmd/nodeagent/nodeagentmanager_test.go
@@ -29,6 +29,7 @@ const (
 	testGameServerName      = "testgs"
 	testGameServerNamespace = "default"
 	testNodeName            = "testnode"
+	testBuildName           = "testBuild"
 	numberOfAttemps         = 3
 )
 
@@ -641,7 +642,13 @@ func createUnstructuredTestGameServer(name, namespace string) *unstructured.Unst
 	g := map[string]interface{}{
 		"apiVersion": "mps.playfab.com/v1alpha1",
 		"kind":       "GameServer",
-		"metadata":   map[string]interface{}{"name": name, "namespace": namespace, "labels": map[string]interface{}{"NodeName": testNodeName}},
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"labels": map[string]interface{}{
+				"NodeName":  testNodeName,
+				"BuildName": testBuildName,
+			}},
 		"spec": map[string]interface{}{
 			"titleID": "testTitleID",
 			"buildID": "testBuildID",

--- a/cmd/nodeagent/utilities.go
+++ b/cmd/nodeagent/utilities.go
@@ -159,14 +159,14 @@ func parseStateHealth(u *unstructured.Unstructured) (string, string, error) {
 	return state, health, nil
 }
 
-// parseBuildID parses and returns the GameServer buildID from the unstructured GameServer CR.
+// parseBuildName parses and returns the GameServerBuild name from the unstructured GameServer CR.
 func parseBuildName(u *unstructured.Unstructured) (string, error) {
-	buildID, buildIDExists, buildIDErr := unstructured.NestedString(u.Object, "metadata", "labels", "BuildName")
-	if buildIDErr != nil {
-		return "", buildIDErr
+	buildName, buildNameExists, buildNameErr := unstructured.NestedString(u.Object, "metadata", "labels", "BuildName")
+	if buildNameErr != nil {
+		return "", buildNameErr
 	}
-	if !buildIDExists {
-		return "", errors.New(ErrBuildIDNotExists)
+	if !buildNameExists {
+		return "", errors.New(ErrBuildNameNotExists)
 	}
-	return buildID, nil
+	return buildName, nil
 }


### PR DESCRIPTION
We noticed that there were a lot of errors during NodeAgent unit tests, because "Build ID is missing". This PR fixes the test by adding Build Name (which was the actual attribute that was missing) in the Unit test objects.