### PR TITLE
fixing webhook test

### DIFF
--- a/pkg/operator/api/v1alpha1/gameserverbuild_webhook_test.go
+++ b/pkg/operator/api/v1alpha1/gameserverbuild_webhook_test.go
@@ -3,12 +3,19 @@ package v1alpha1
 import (
 	"math/rand"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	timeout  = time.Second * 5
+	interval = time.Millisecond * 250
 )
 
 var _ = Describe("GameServerBuild webhook tests", func() {
@@ -19,6 +26,12 @@ var _ = Describe("GameServerBuild webhook tests", func() {
 			buildName2, _ := getNewNameAndID()
 			gsb := createTestGameServerBuild(buildName, buildID, 2, 4, false)
 			Expect(k8sClient.Create(ctx, &gsb)).Should(Succeed())
+			// make sure the new GameServerBuild is part of the cache
+			var gsbTest GameServerBuild
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: buildName, Namespace: "default"}, &gsbTest)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
 			gsb = createTestGameServerBuild(buildName2, buildID, 2, 4, false)
 			err := k8sClient.Create(ctx, &gsb)
 			Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Occasionally, we've seen a webhook test fails since the GameServerBuilds are created fast and so a subsequent call with the same BuildID will bypass the cache. For example https://github.com/PlayFab/thundernetes/runs/6874395350?check_suite_focus=true

This PR adds code to check that the new GameServerBuild is part of the cache before proceeding.