### PR TITLE
Increase first heartbeat timeout

### DIFF
--- a/cmd/nodeagent/nodeagentmanager.go
+++ b/cmd/nodeagent/nodeagentmanager.go
@@ -95,7 +95,7 @@ func (n *NodeAgentManager) runWatch() {
 // runHeartbeatTimeCheckerLoop runs HeartbeatTimeChecker on an infinite loop
 func (n *NodeAgentManager) runHeartbeatTimeCheckerLoop() {
 	n.firstHeartbeatTimeout = ParseInt64FromEnv("FIRST_HEARTBEAT_TIMEOUT", 60000)
-	n.heartbeatTimeout = ParseInt64FromEnv("HEARTBEAT_TIMEOUT", 5000)
+	n.heartbeatTimeout = ParseInt64FromEnv("HEARTBEAT_TIMEOUT", 60000)
 	go func() {
 		for {
 			n.HeartbeatTimeChecker()


### PR DESCRIPTION
This PR increases the timeout for the first heartbeat from a game server to 60 seconds.