### PR TITLE
fix required fields bug

### DIFF
--- a/installfiles/operator.yaml
+++ b/installfiles/operator.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverbuilds.mps.playfab.com
 spec:
   conversion:
@@ -63,7 +63,8 @@ spec:
             description: GameServerBuildSpec defines the desired state of GameServerBuild
             properties:
               buildID:
-                description: Build is is the BuildID for this Build
+                description: BuildID is is the BuildID for this Build
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for this GameServerBuild
@@ -4190,7 +4191,15 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this Build belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - max
+            - portsToExpose
+            - standingBy
+            - titleID
             type: object
           status:
             description: GameServerBuildStatus defines the observed state of GameServerBuild
@@ -4228,19 +4237,13 @@ spec:
         specReplicasPath: .spec.standingBy
         statusReplicasPath: .status.currentStandingBy
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverdetails.mps.playfab.com
 spec:
   conversion:
@@ -4298,18 +4301,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: gameservers.mps.playfab.com
 spec:
@@ -4356,7 +4353,8 @@ spec:
             description: GameServerSpec defines the desired state of GameServer
             properties:
               buildID:
-                description: Build is the BuildID for this GameServer
+                description: BuildID is the BuildID for this GameServer
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for the GameServerBuild this GameServer belongs to
@@ -8470,7 +8468,14 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this GameServer belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - portsToExpose
+            - template
+            - titleID
             type: object
           status:
             description: GameServerStatus defines the observed state of GameServer
@@ -8519,12 +8524,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/installfiles/operator_with_monitoring.yaml
+++ b/installfiles/operator_with_monitoring.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverbuilds.mps.playfab.com
 spec:
   conversion:
@@ -63,7 +63,8 @@ spec:
             description: GameServerBuildSpec defines the desired state of GameServerBuild
             properties:
               buildID:
-                description: Build is is the BuildID for this Build
+                description: BuildID is is the BuildID for this Build
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for this GameServerBuild
@@ -4190,7 +4191,15 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this Build belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - max
+            - portsToExpose
+            - standingBy
+            - titleID
             type: object
           status:
             description: GameServerBuildStatus defines the observed state of GameServerBuild
@@ -4228,19 +4237,13 @@ spec:
         specReplicasPath: .spec.standingBy
         statusReplicasPath: .status.currentStandingBy
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverdetails.mps.playfab.com
 spec:
   conversion:
@@ -4298,18 +4301,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: gameservers.mps.playfab.com
 spec:
@@ -4356,7 +4353,8 @@ spec:
             description: GameServerSpec defines the desired state of GameServer
             properties:
               buildID:
-                description: Build is the BuildID for this GameServer
+                description: BuildID is the BuildID for this GameServer
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for the GameServerBuild this GameServer belongs to
@@ -8470,7 +8468,14 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this GameServer belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - portsToExpose
+            - template
+            - titleID
             type: object
           status:
             description: GameServerStatus defines the observed state of GameServer
@@ -8519,12 +8524,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/installfiles/operator_with_security.yaml
+++ b/installfiles/operator_with_security.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverbuilds.mps.playfab.com
 spec:
   conversion:
@@ -63,7 +63,8 @@ spec:
             description: GameServerBuildSpec defines the desired state of GameServerBuild
             properties:
               buildID:
-                description: Build is is the BuildID for this Build
+                description: BuildID is is the BuildID for this Build
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for this GameServerBuild
@@ -4190,7 +4191,15 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this Build belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - max
+            - portsToExpose
+            - standingBy
+            - titleID
             type: object
           status:
             description: GameServerBuildStatus defines the observed state of GameServerBuild
@@ -4228,19 +4237,13 @@ spec:
         specReplicasPath: .spec.standingBy
         statusReplicasPath: .status.currentStandingBy
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverdetails.mps.playfab.com
 spec:
   conversion:
@@ -4298,18 +4301,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: gameservers.mps.playfab.com
 spec:
@@ -4356,7 +4353,8 @@ spec:
             description: GameServerSpec defines the desired state of GameServer
             properties:
               buildID:
-                description: Build is the BuildID for this GameServer
+                description: BuildID is the BuildID for this GameServer
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for the GameServerBuild this GameServer belongs to
@@ -8470,7 +8468,14 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this GameServer belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - portsToExpose
+            - template
+            - titleID
             type: object
           status:
             description: GameServerStatus defines the observed state of GameServer
@@ -8519,12 +8524,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/installfiles/operator_with_security_and_monitoring.yaml
+++ b/installfiles/operator_with_security_and_monitoring.yaml
@@ -10,7 +10,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverbuilds.mps.playfab.com
 spec:
   conversion:
@@ -63,7 +63,8 @@ spec:
             description: GameServerBuildSpec defines the desired state of GameServerBuild
             properties:
               buildID:
-                description: Build is is the BuildID for this Build
+                description: BuildID is is the BuildID for this Build
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for this GameServerBuild
@@ -4190,7 +4191,15 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this Build belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - max
+            - portsToExpose
+            - standingBy
+            - titleID
             type: object
           status:
             description: GameServerBuildStatus defines the observed state of GameServerBuild
@@ -4228,19 +4237,13 @@ spec:
         specReplicasPath: .spec.standingBy
         statusReplicasPath: .status.currentStandingBy
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: thundernetes-system/thundernetes-serving-cert
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   name: gameserverdetails.mps.playfab.com
 spec:
   conversion:
@@ -4298,18 +4301,12 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: gameservers.mps.playfab.com
 spec:
@@ -4356,7 +4353,8 @@ spec:
             description: GameServerSpec defines the desired state of GameServer
             properties:
               buildID:
-                description: Build is the BuildID for this GameServer
+                description: BuildID is the BuildID for this GameServer
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for the GameServerBuild this GameServer belongs to
@@ -8470,7 +8468,14 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this GameServer belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - portsToExpose
+            - template
+            - titleID
             type: object
           status:
             description: GameServerStatus defines the observed state of GameServer
@@ -8519,12 +8524,6 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/operator/Makefile
+++ b/pkg/operator/Makefile
@@ -132,7 +132,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/pkg/operator/api/v1alpha1/gameserver_types.go
+++ b/pkg/operator/api/v1alpha1/gameserver_types.go
@@ -51,17 +51,25 @@ type GameServerSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	//+kubebuilder:validation:Required
 	// Template describes the pod template specification of the game server
-	Template corev1.PodTemplateSpec `json:"template,omitempty"`
+	Template corev1.PodTemplateSpec `json:"template"`
+
 	//+kubebuilder:validation:Required
+	//+kubebuilder:validation:Format=string
+	//+kubebuilder:validation:MinLength=1
 	// TitleID is the TitleID this GameServer belongs to
-	TitleID string `json:"titleID,omitempty"`
+	TitleID string `json:"titleID"`
+
 	//+kubebuilder:validation:Required
-	// Build is the BuildID for this GameServer
-	BuildID string `json:"buildID,omitempty"`
+	//+kubebuilder:validation:Format=uuid
+	// BuildID is the BuildID for this GameServer
+	BuildID string `json:"buildID"`
+
 	//+kubebuilder:validation:Required
 	// PortsToExpose is an array of ports that will be exposed on the VM
-	PortsToExpose []int32 `json:"portsToExpose,omitempty"`
+	PortsToExpose []int32 `json:"portsToExpose"`
+
 	// BuildMetadata is the metadata for the GameServerBuild this GameServer belongs to
 	BuildMetadata []BuildMetadataItem `json:"buildMetadata,omitempty"`
 }

--- a/pkg/operator/api/v1alpha1/gameserver_webhook_test.go
+++ b/pkg/operator/api/v1alpha1/gameserver_webhook_test.go
@@ -54,6 +54,7 @@ var _ = Describe("GameServer webhook tests", func() {
 func createTestGameServer(name, buildID string, hostNetwork bool) GameServer {
 	return GameServer{
 		Spec: GameServerSpec{
+			TitleID:       "test-title-id",
 			BuildID:       buildID,
 			PortsToExpose: []int32{80},
 			Template: corev1.PodTemplateSpec{

--- a/pkg/operator/api/v1alpha1/gameserverbuild_types.go
+++ b/pkg/operator/api/v1alpha1/gameserverbuild_types.go
@@ -39,27 +39,33 @@ type GameServerBuildSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	//+kubebuilder:validation:Required
 	//+kubebuilder:validation:Minimum=0
 	// StandingBy is the requested number of standingBy servers
-	StandingBy int `json:"standingBy,omitempty"`
+	StandingBy int `json:"standingBy"`
+	//+kubebuilder:validation:Required
 	//+kubebuilder:validation:Minimum=0
 	// Max is the maximum number of servers in any state
-	Max int `json:"max,omitempty"`
+	Max int `json:"max"`
 
+	//+kubebuilder:validation:Required
 	// Template describes the pod template specification of the game server
 	Template corev1.PodTemplateSpec `json:"template,omitempty"`
 
 	//+kubebuilder:validation:Required
+	//+kubebuilder:validation:Format=string
+	//+kubebuilder:validation:MinLength=1
 	// TitleID is the TitleID this Build belongs to
-	TitleID string `json:"titleID,omitempty"`
+	TitleID string `json:"titleID"`
 
 	//+kubebuilder:validation:Required
-	// Build is is the BuildID for this Build
-	BuildID string `json:"buildID,omitempty"`
+	//+kubebuilder:validation:Format=uuid
+	// BuildID is is the BuildID for this Build
+	BuildID string `json:"buildID"`
 
 	//+kubebuilder:validation:Required
 	// PortsToExpose is an array of ports that will be exposed on the VM
-	PortsToExpose []int32 `json:"portsToExpose,omitempty"`
+	PortsToExpose []int32 `json:"portsToExpose"`
 
 	//+kubebuilder:default=5
 	//+kubebuilder:validation:Minimum=0

--- a/pkg/operator/api/v1alpha1/gameserverbuild_webhook_test.go
+++ b/pkg/operator/api/v1alpha1/gameserverbuild_webhook_test.go
@@ -95,6 +95,7 @@ func randString(n int) string {
 func createTestGameServerBuild(buildName, buildID string, standingBy, max int, hostNetwork bool) GameServerBuild {
 	return GameServerBuild{
 		Spec: GameServerBuildSpec{
+			TitleID:       "test-title-id",
 			BuildID:       buildID,
 			StandingBy:    standingBy,
 			Max:           max,

--- a/pkg/operator/config/crd/bases/mps.playfab.com_gameserverbuilds.yaml
+++ b/pkg/operator/config/crd/bases/mps.playfab.com_gameserverbuilds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: gameserverbuilds.mps.playfab.com
 spec:
@@ -51,7 +51,8 @@ spec:
             description: GameServerBuildSpec defines the desired state of GameServerBuild
             properties:
               buildID:
-                description: Build is is the BuildID for this Build
+                description: BuildID is is the BuildID for this Build
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for this GameServerBuild
@@ -7209,7 +7210,15 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this Build belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - max
+            - portsToExpose
+            - standingBy
+            - titleID
             type: object
           status:
             description: GameServerBuildStatus defines the observed state of GameServerBuild
@@ -7249,9 +7258,3 @@ spec:
         specReplicasPath: .spec.standingBy
         statusReplicasPath: .status.currentStandingBy
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/operator/config/crd/bases/mps.playfab.com_gameserverdetails.yaml
+++ b/pkg/operator/config/crd/bases/mps.playfab.com_gameserverdetails.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: gameserverdetails.mps.playfab.com
 spec:
@@ -56,9 +56,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/operator/config/crd/bases/mps.playfab.com_gameservers.yaml
+++ b/pkg/operator/config/crd/bases/mps.playfab.com_gameservers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
   name: gameservers.mps.playfab.com
 spec:
@@ -54,7 +54,8 @@ spec:
             description: GameServerSpec defines the desired state of GameServer
             properties:
               buildID:
-                description: Build is the BuildID for this GameServer
+                description: BuildID is the BuildID for this GameServer
+                format: uuid
                 type: string
               buildMetadata:
                 description: BuildMetadata is the metadata for the GameServerBuild
@@ -7199,7 +7200,14 @@ spec:
                 type: object
               titleID:
                 description: TitleID is the TitleID this GameServer belongs to
+                format: string
+                minLength: 1
                 type: string
+            required:
+            - buildID
+            - portsToExpose
+            - template
+            - titleID
             type: object
           status:
             description: GameServerStatus defines the observed state of GameServer
@@ -7256,9 +7264,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/operator/controllers/gameserverbuild_controller_test.go
+++ b/pkg/operator/controllers/gameserverbuild_controller_test.go
@@ -180,5 +180,27 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			testVerifyTotalGameServerCount(ctx, buildID, 2)
 			verifyContainerPortIsTheSameAsHostPort(ctx, buildName)
 		})
+
+		It("should fail to create a GameServerBuild without a titleID", func() {
+			buildName, buildID := getNewBuildNameAndID()
+			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, true)
+			gsb.Spec.TitleID = ""
+			err := testk8sClient.Create(ctx, &gsb)
+			Expect(err).ToNot(BeNil())
+		})
+
+		It("should fail to create a GameServerBuild without a buildID", func() {
+			buildName, buildID := getNewBuildNameAndID()
+			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, true)
+			gsb.Spec.BuildID = ""
+			Expect(testk8sClient.Create(ctx, &gsb)).Should(Not(Succeed()))
+		})
+
+		It("should fail to create a GameServerBuild with a non-GUID buildID", func() {
+			buildName, buildID := getNewBuildNameAndID()
+			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, true)
+			gsb.Spec.BuildID = "1234"
+			Expect(testk8sClient.Create(ctx, &gsb)).Should(Not(Succeed()))
+		})
 	})
 })

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -115,6 +115,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
+		defer GinkgoRecover()
 		err = k8sManager.Start(ctrl.SetupSignalHandler())
 		Expect(err).ToNot(HaveOccurred())
 	}()

--- a/pkg/operator/controllers/test_utils_test.go
+++ b/pkg/operator/controllers/test_utils_test.go
@@ -182,9 +182,11 @@ func testUpdateInitializingGameServersToStandingBy(ctx context.Context, buildID 
 func testGenerateGameServerBuild(buildName, buildNamespace, buildID string, standingBy, max int, hostNetwork bool) mpsv1alpha1.GameServerBuild {
 	return mpsv1alpha1.GameServerBuild{
 		Spec: mpsv1alpha1.GameServerBuildSpec{
-			BuildID:    buildID,
-			StandingBy: standingBy,
-			Max:        max,
+			PortsToExpose: []int32{80},
+			TitleID:       "test-title-id",
+			BuildID:       buildID,
+			StandingBy:    standingBy,
+			Max:           max,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -213,7 +215,9 @@ func testGenerateGameServerBuild(buildName, buildNamespace, buildID string, stan
 func testGenerateGameServer(buildName, buildID, gsNamespace, gsName string) *mpsv1alpha1.GameServer {
 	return &mpsv1alpha1.GameServer{
 		Spec: mpsv1alpha1.GameServerSpec{
-			BuildID: buildID,
+			TitleID:       "testtitleid",
+			PortsToExpose: []int32{80},
+			BuildID:       buildID,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      map[string]string{"label1": "value1", "label2": "value2"},


### PR DESCRIPTION
While working on #265, we discovered that the presence of `omitEmpty` on the CR type definition makes the field optional and the `required` annotation is ignored. This PR fixes it. Opportunistically, we update controller-tools to 0.9.0.
PR also updates current installation files. We're adding behavior that should already be there, so no new Thundernetes version is required.

For reference: https://github.com/kubernetes-sigs/controller-tools/issues/599