### PR TITLE
adding a timeout to a gameserver api test

### DIFF
--- a/cmd/e2e/gameserverapi_test.go
+++ b/cmd/e2e/gameserverapi_test.go
@@ -143,7 +143,7 @@ var _ = Describe("GameServerAPI tests", func() {
 			// check that GameServers have a NodeName and a PublicIP
 			g.Expect(gs.Status.NodeName).ToNot(BeEmpty())
 			g.Expect(net.ParseIP(gs.Status.PublicIP)).ToNot(BeNil())
-		}).Should(Succeed())
+		}, timeout, interval).Should(Succeed())
 
 		// delete this GameServer
 		req1, err := http.NewRequest("DELETE", fmt.Sprintf("%s/gameservers/%s/%s", url, testNamespace, gsName), nil)


### PR DESCRIPTION
Hotfix to fix a transient error on the gameserver API test routine, we saw it here: https://github.com/PlayFab/thundernetes/runs/7309434067?check_suite_focus=true