### PR TITLE
fixing deletion ordering

### DIFF
--- a/pkg/operator/controllers/allocation_api_server_test.go
+++ b/pkg/operator/controllers/allocation_api_server_test.go
@@ -126,7 +126,7 @@ var _ = Describe("allocation API service queue tests", func() {
 		Expect(testk8sClient.Create(context.Background(), &gsb)).Should(Succeed())
 		testVerifyTotalGameServerCount(context.Background(), buildID1, 2)
 		testUpdateInitializingGameServersToStandingBy(context.Background(), buildID1)
-		testVerifyStandingByActiveByCount(context.Background(), buildID1, 2, 0)
+		testVerifyInitializingStandingByActiveByCount(context.Background(), buildID1, 0, 2, 0)
 		// verify that references exist in queue
 		Eventually(func(g Gomega) {
 			testAllocationApiServer.gameServerQueue.mutex.RLock()
@@ -174,9 +174,9 @@ var _ = Describe("allocation API service queue tests", func() {
 
 		// downscale the Build to one standingBy
 		Eventually(func(g Gomega) {
-			testVerifyStandingByActiveByCount(context.Background(), buildID1, 2, 2)
+			testVerifyInitializingStandingByActiveByCount(context.Background(), buildID1, 0, 2, 2)
 			testUpdateGameServerBuild(context.Background(), 1, 4, buildName1)
-			testVerifyStandingByActiveByCount(context.Background(), buildID1, 1, 2)
+			testVerifyInitializingStandingByActiveByCount(context.Background(), buildID1, 0, 1, 2)
 		}).Should(Succeed())
 
 		// validate that there is one game server in the queue
@@ -192,7 +192,7 @@ var _ = Describe("allocation API service queue tests", func() {
 		// downscale the Build to zero standingBy
 		Eventually(func(g Gomega) {
 			testUpdateGameServerBuild(context.Background(), 0, 4, buildName1)
-			testVerifyStandingByActiveByCount(context.Background(), buildID1, 0, 2)
+			testVerifyInitializingStandingByActiveByCount(context.Background(), buildID1, 0, 0, 2)
 		}).Should(Succeed())
 
 		// validate that there are no more game servers in the queue

--- a/pkg/operator/controllers/controller_utils.go
+++ b/pkg/operator/controllers/controller_utils.go
@@ -432,3 +432,31 @@ func IsNodeReadyAndSchedulable(node *corev1.Node) bool {
 func useSpecificNodePoolAndNodeNotGameServer(useSpecificNodePool bool, node *corev1.Node) bool {
 	return useSpecificNodePool && node.Labels[LabelGameServerNode] != "true"
 }
+
+// ByState is a slice of GameServers
+type ByState []mpsv1alpha1.GameServer
+
+// Len is the number of elements in the collection
+func (gs ByState) Len() int { return len(gs) }
+
+// Less helps sort the GameServer slice by the following order
+// first are the Initializing GameServers and then the StandingBy
+// everything else goes last
+func (gs ByState) Less(i, j int) bool {
+	return getValueByState(&gs[i]) < getValueByState(&gs[j])
+}
+
+// Swap swaps the elements at the passed indexes
+func (gs ByState) Swap(i, j int) { gs[i], gs[j] = gs[j], gs[i] }
+
+// getValueByState returns the value of the state of the GameServer
+// to help in sorting the array
+func getValueByState(gs *mpsv1alpha1.GameServer) int {
+	if gs.Status.State == "" || gs.Status.State == mpsv1alpha1.GameServerStateInitializing {
+		return 0
+	} else if gs.Status.State == mpsv1alpha1.GameServerStateStandingBy {
+		return 1
+	} else {
+		return 2
+	}
+}

--- a/pkg/operator/controllers/controller_utils.go
+++ b/pkg/operator/controllers/controller_utils.go
@@ -451,12 +451,18 @@ func (gs ByState) Swap(i, j int) { gs[i], gs[j] = gs[j], gs[i] }
 
 // getValueByState returns the value of the state of the GameServer
 // to help in sorting the array
+// we want to delete the GameServers that are in empty ("") state first (since they might have Pods Pending or waiting to start)
+// then the ones on Initializing state
+// and lastly the ones on StandingBy state
+// GameServers that have crashed or Terminated are taken care of when the GameServerBuild controller starts
 func getValueByState(gs *mpsv1alpha1.GameServer) int {
-	if gs.Status.State == "" || gs.Status.State == mpsv1alpha1.GameServerStateInitializing {
+	if gs.Status.State == "" {
 		return 0
-	} else if gs.Status.State == mpsv1alpha1.GameServerStateStandingBy {
+	} else if gs.Status.State == mpsv1alpha1.GameServerStateInitializing {
 		return 1
-	} else {
+	} else if gs.Status.State == mpsv1alpha1.GameServerStateStandingBy {
 		return 2
+	} else {
+		return 3
 	}
 }

--- a/pkg/operator/controllers/gameserverbuild_controller.go
+++ b/pkg/operator/controllers/gameserverbuild_controller.go
@@ -409,6 +409,8 @@ func (r *GameServerBuildReconciler) deleteNonActiveGameServers(ctx context.Conte
 	// a waitgroup for async deletion calls
 	var wg sync.WaitGroup
 	deletionCalls := 0
+	// we sort the GameServers by state so that we can delete the ones that are empty state or Initializing before we delete the StandingBy ones (if needed)
+	// this is to make sure we don't fall below the desired number of StandingBy during scaling down
 	sort.Sort(ByState(gameServers.Items))
 	for i := 0; i < len(gameServers.Items) && deletionCalls < totalNumberOfGameServersToDelete; i++ {
 		gs := gameServers.Items[i]

--- a/pkg/operator/controllers/gameserverbuild_controller.go
+++ b/pkg/operator/controllers/gameserverbuild_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math"
 	"runtime"
+	"sort"
 	"sync"
 
 	mpsv1alpha1 "github.com/playfab/thundernetes/pkg/operator/api/v1alpha1"
@@ -408,6 +409,7 @@ func (r *GameServerBuildReconciler) deleteNonActiveGameServers(ctx context.Conte
 	// a waitgroup for async deletion calls
 	var wg sync.WaitGroup
 	deletionCalls := 0
+	sort.Sort(ByState(gameServers.Items))
 	for i := 0; i < len(gameServers.Items) && deletionCalls < totalNumberOfGameServersToDelete; i++ {
 		gs := gameServers.Items[i]
 		// we're deleting only initializing/pending/standingBy servers, never touching active

--- a/pkg/operator/controllers/gameserverbuild_controller_test.go
+++ b/pkg/operator/controllers/gameserverbuild_controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/playfab/thundernetes/pkg/operator/api/v1alpha1"
 )
 
 const (
@@ -18,12 +19,11 @@ var _ = Describe("GameServerBuild controller tests", func() {
 		ctx := context.Background()
 
 		// tests here follow the flow
-		// 1. create a gameserverbuild
-		// 2. verify that we have the requested count of GameServer CRs
-		// 3. since we don't have containers running (so the daemonset can update the GameServer.Status), we manually
-		//    set the initializing GameServers' .Status to standingBy
-		// 4. verify the number of standingBy and active GameServers
-		// It's important to verify that the requested number of GameServers has been created, since if we
+		// 1. create a GameServerBuild
+		// 2. verify that we have the requested count of GameServer CRs. This also "waits" for these GameServers, so we can update them
+		// 3. since we don't have containers running (so the NodeAgent DaemonSet can update the GameServer.Status), we manually set the initializing GameServers' .Status to standingBy
+		// 4. verify the number of empty state, initializing, standingBy and active GameServers
+		// Note: On the second item in the above list, it's important to verify that the requested number of GameServers has been created, since if we
 		// try to fetch them to update their .Status, we might end up in a state that they have not been created yet on the API server
 
 		// tests the creation of game servers
@@ -31,9 +31,9 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, false)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 2)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 2)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 0})
 		})
 
 		// simple scaling test
@@ -41,47 +41,47 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, false)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 2)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 2)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 0})
 
 			testUpdateGameServerBuild(ctx, 4, 4, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 4, 0})
 		})
 		// controller should block creating ">max" GameServers
 		It("should not scale game servers beyond max", func() {
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, false)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 2)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 2)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 0})
 
 			testUpdateGameServerBuild(ctx, 5, 4, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 4, 0})
 		})
 		// however, when we increase the max, controller should create the additional GameServers
 		It("should scale game servers when max is increasing", func() {
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, false)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 2)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 2)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 0})
 
 			testUpdateGameServerBuild(ctx, 5, 4, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 4, 0})
 
 			testUpdateGameServerBuild(ctx, 5, 5, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 5)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 5, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 5)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 5, 0})
 		})
 
 		// manual allocation by manually setting .GameServer.Status.State to "Active"
@@ -89,64 +89,64 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, false)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 2)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 2)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 0})
 
 			// allocate two GameServers and watch that new StandingBys are being created
 			allocateGameServerManually(ctx, buildID)
-			testVerifyTotalGameServerCount(ctx, buildID, 3)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 1)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 3)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 1})
 
 			allocateGameServerManually(ctx, buildID)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 2)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 2})
 
 			// another scaling test, increase the standingBy to 4 and max to 6
 			// since we have 2 active, we should have 4 standingBy
 			testUpdateGameServerBuild(ctx, 4, 6, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 6)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 2)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 6)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 4, 2})
 		})
 
 		It("should create new game servers if game sessions end", func() {
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 4, 4, false)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 4, 0})
 
 			// allocate two game servers, end up with 2 standingBy and 2 active
 			allocateGameServerManually(ctx, buildID)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 3, 1)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 3, 1})
 
 			allocateGameServerManually(ctx, buildID)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 2)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 2, 2})
 
 			// gracefully end the game session for one game server
 			// we wait till we have a new GameServer, since it'll take one reconcile loop for the controller to notice the GameServer has exited
 			// once we get that, we verify that the controller has created a new GameServer
 			testTerminateActiveGameServer(ctx, buildID, true)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 1, 2, 1)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 3, 1)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testVerifyGameServerStates(ctx, buildID, testStates{1, 0, 2, 1})
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 3, 1})
 
 			// as before, we gracefully terminate the second active GameServer
 			// we now should have 4 standingBy
 			testTerminateActiveGameServer(ctx, buildID, true)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 1, 3, 0)
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testVerifyGameServerStates(ctx, buildID, testStates{1, 0, 3, 0})
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 4, 0})
 		})
 
 		It("should mark Build as unhealthy when there are too many crashes", func() {
@@ -156,16 +156,15 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			crashes := 5
 			gsb.Spec.CrashesToMarkUnhealthy = &crashes
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 6)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 6, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 6)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 6, 0})
 
 			// allocate 5 times
 			for i := 0; i < 5; i++ {
 				allocateGameServerManually(ctx, buildID)
 			}
-			testVerifyTotalGameServerCount(ctx, buildID, 6)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 1, 5)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 1, 5})
 
 			// simulate 5 crashes (5 is the default value for GameServerBuild to be marked as Unhealthy)
 			for i := 0; i < 5; i++ {
@@ -175,32 +174,43 @@ var _ = Describe("GameServerBuild controller tests", func() {
 		})
 
 		It("should delete initializing servers before deleting standingBy, during downscaling", func() {
-			// create a new GameServerBuild with 4 standingBy and 8 max
+			// create a new GameServerBuild with 4 standingBy and 16 max
 			buildName, buildID := getNewBuildNameAndID()
-			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 4, 8, false)
+			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 4, 16, false)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 4)
-			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateStandingBy)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 4, 0})
 
 			// upscale the GameServerBuild to 8 requested standingBy
-			testUpdateGameServerBuild(ctx, 8, 8, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 8)
-			// we don't modify the state of the 4 GameServers so they should be initializing
-			// we still have 4 standingBy
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 4, 4, 0)
+			testUpdateGameServerBuild(ctx, 8, 16, buildName)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 8)
+			testUpdateGameServersState(ctx, buildID, "", v1alpha1.GameServerStateInitializing)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 4, 4, 0})
 
-			// downscale the GameServerBuild to 5 requested standingBy
-			// 3 initializing should have been deleted
-			testUpdateGameServerBuild(ctx, 5, 8, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 5)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 1, 4, 0)
+			// upscale the GameServerBuild to 10 requested standingBy
+			testUpdateGameServerBuild(ctx, 10, 16, buildName)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 10)
+			testVerifyGameServerStates(ctx, buildID, testStates{2, 4, 4, 0})
+
+			// downscale the GameServerBuild to 9 requested standingBy
+			// we want one GameServer to be deleted, this has to be one with empty state
+			testUpdateGameServerBuild(ctx, 9, 16, buildName)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 9)
+			testVerifyGameServerStates(ctx, buildID, testStates{1, 4, 4, 0})
+
+			// downscale the GameServerBuild to 7 requested standingBy
+			// we want two GameServers to be deleted, so we'll take down the remaining one with empty state
+			// and one StandingBy
+			testUpdateGameServerBuild(ctx, 7, 16, buildName)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 7)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 3, 4, 0})
 
 			// downscale the GameServerBuild to 3 requested standingBy
-			// 1 initializing and 1 standingBy should have been deleted
-			testUpdateGameServerBuild(ctx, 3, 8, buildName)
-			testVerifyTotalGameServerCount(ctx, buildID, 3)
-			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 3, 0)
+			// all 3 initializing and 1 standingBy should have been deleted
+			testUpdateGameServerBuild(ctx, 3, 16, buildName)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 3)
+			testVerifyGameServerStates(ctx, buildID, testStates{0, 0, 3, 0})
 		})
 
 		It("should overwrite containerPort with hostPort value when hostNetwork is required", func() {
@@ -208,7 +218,8 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, true)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
-			testVerifyTotalGameServerCount(ctx, buildID, 2)
+			testWaitAndVerifyTotalGameServerCount(ctx, buildID, 2)
+			testVerifyGameServerStates(ctx, buildID, testStates{2, 0, 0, 0})
 			verifyContainerPortIsTheSameAsHostPort(ctx, buildName)
 		})
 

--- a/pkg/operator/controllers/gameserverbuild_controller_test.go
+++ b/pkg/operator/controllers/gameserverbuild_controller_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
 			testVerifyTotalGameServerCount(ctx, buildID, 2)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
 		})
 
 		// simple scaling test
@@ -43,12 +43,12 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
 			testVerifyTotalGameServerCount(ctx, buildID, 2)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
 
 			testUpdateGameServerBuild(ctx, 4, 4, buildName)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 4, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
 		})
 		// controller should block creating ">max" GameServers
 		It("should not scale game servers beyond max", func() {
@@ -57,12 +57,12 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
 			testVerifyTotalGameServerCount(ctx, buildID, 2)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
 
 			testUpdateGameServerBuild(ctx, 5, 4, buildName)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 4, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
 		})
 		// however, when we increase the max, controller should create the additional GameServers
 		It("should scale game servers when max is increasing", func() {
@@ -71,17 +71,17 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
 			testVerifyTotalGameServerCount(ctx, buildID, 2)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
 
 			testUpdateGameServerBuild(ctx, 5, 4, buildName)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 4, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
 
 			testUpdateGameServerBuild(ctx, 5, 5, buildName)
 			testVerifyTotalGameServerCount(ctx, buildID, 5)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 5, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 5, 0)
 		})
 
 		// manual allocation by manually setting .GameServer.Status.State to "Active"
@@ -91,25 +91,25 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
 			testVerifyTotalGameServerCount(ctx, buildID, 2)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 0)
 
 			// allocate two GameServers and watch that new StandingBys are being created
 			allocateGameServerManually(ctx, buildID)
 			testVerifyTotalGameServerCount(ctx, buildID, 3)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 1)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 1)
 
 			allocateGameServerManually(ctx, buildID)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 2)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 2)
 
 			// another scaling test, increase the standingBy to 4 and max to 6
 			// since we have 2 active, we should have 4 standingBy
 			testUpdateGameServerBuild(ctx, 4, 6, buildName)
 			testVerifyTotalGameServerCount(ctx, buildID, 6)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 4, 2)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 2)
 		})
 
 		It("should create new game servers if game sessions end", func() {
@@ -118,35 +118,35 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 4, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
 
 			// allocate two game servers, end up with 2 standingBy and 2 active
 			allocateGameServerManually(ctx, buildID)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 3, 1)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 3, 1)
 
 			allocateGameServerManually(ctx, buildID)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 2, 2)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 2, 2)
 
 			// gracefully end the game session for one game server
 			// we wait till we have a new GameServer, since it'll take one reconcile loop for the controller to notice the GameServer has exited
 			// once we get that, we verify that the controller has created a new GameServer
 			testTerminateActiveGameServer(ctx, buildID, true)
-			testVerifyGameServersForBuildAreInitializing(ctx, buildID, 1)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 1, 2, 1)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 3, 1)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 3, 1)
 
 			// as before, we gracefully terminate the second active GameServer
 			// we now should have 4 standingBy
 			testTerminateActiveGameServer(ctx, buildID, true)
-			testVerifyGameServersForBuildAreInitializing(ctx, buildID, 1)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 1, 3, 0)
 			testVerifyTotalGameServerCount(ctx, buildID, 4)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 4, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
 		})
 
 		It("should mark Build as unhealthy when there are too many crashes", func() {
@@ -158,14 +158,14 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
 			testVerifyTotalGameServerCount(ctx, buildID, 6)
 			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
-			testVerifyStandingByActiveByCount(ctx, buildID, 6, 0)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 6, 0)
 
 			// allocate 5 times
 			for i := 0; i < 5; i++ {
 				allocateGameServerManually(ctx, buildID)
 			}
 			testVerifyTotalGameServerCount(ctx, buildID, 6)
-			testVerifyStandingByActiveByCount(ctx, buildID, 1, 5)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 1, 5)
 
 			// simulate 5 crashes (5 is the default value for GameServerBuild to be marked as Unhealthy)
 			for i := 0; i < 5; i++ {
@@ -174,8 +174,37 @@ var _ = Describe("GameServerBuild controller tests", func() {
 			verifyThatBuildIsUnhealthy(ctx, buildName)
 		})
 
+		It("should delete initializing servers before deleting standingBy, during downscaling", func() {
+			// create a new GameServerBuild with 4 standingBy and 8 max
+			buildName, buildID := getNewBuildNameAndID()
+			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 4, 8, false)
+			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())
+			testVerifyTotalGameServerCount(ctx, buildID, 4)
+			testUpdateInitializingGameServersToStandingBy(ctx, buildID)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 4, 0)
+
+			// upscale the GameServerBuild to 8 requested standingBy
+			testUpdateGameServerBuild(ctx, 8, 8, buildName)
+			testVerifyTotalGameServerCount(ctx, buildID, 8)
+			// we don't modify the state of the 4 GameServers so they should be initializing
+			// we still have 4 standingBy
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 4, 4, 0)
+
+			// downscale the GameServerBuild to 5 requested standingBy
+			// 3 initializing should have been deleted
+			testUpdateGameServerBuild(ctx, 5, 8, buildName)
+			testVerifyTotalGameServerCount(ctx, buildID, 5)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 1, 4, 0)
+
+			// downscale the GameServerBuild to 3 requested standingBy
+			// 1 initializing and 1 standingBy should have been deleted
+			testUpdateGameServerBuild(ctx, 3, 8, buildName)
+			testVerifyTotalGameServerCount(ctx, buildID, 3)
+			testVerifyInitializingStandingByActiveByCount(ctx, buildID, 0, 3, 0)
+		})
+
 		It("should overwrite containerPort with hostPort value when hostNetwork is required", func() {
-			// create a Build with 6 standingBy
+			// create a Build with 2 standingBy
 			buildName, buildID := getNewBuildNameAndID()
 			gsb := testGenerateGameServerBuild(buildName, testnamespace, buildID, 2, 4, true)
 			Expect(testk8sClient.Create(ctx, &gsb)).Should(Succeed())


### PR DESCRIPTION
When downscaling, the GameServerBuild controller did not distinguish between Initializing and StandingBy GameServers. If a GameServerBuild is upscaling (e.g. waiting for a new Node to join the cluster) and the user starts a downscaling, this can have the impact of StandingBy GameServers being deleted before the Initializing ones. This way, the GameServerBuild will be a little slower to reach the required StandingBy levels.
This PR adds some logic to the GameServerBuild controller to sort the GameServer slice before deletion, so that the Initializing GameServers come before the StandiingBy.

Opportunistically, we refactored the tests on the GameServerBuild controller.