### PR TITLE
Hiding footer page from navigation

### DIFF
--- a/docs/gsdk/gsdkfooter.md
+++ b/docs/gsdk/gsdkfooter.md
@@ -1,3 +1,8 @@
+---
+layout: default
+nav_exclude: true
+---
+
 ### Testing with LocalMultiplayerAgent
 
 You can use [LocalMultiplayerAgent](runlocalmultiplayeragent.html) to test your GSDK integration of your game server before uploading to Thundernetes.


### PR DESCRIPTION
This PR adds a tag to remove the GSDK footer page from site's navigation.