### PR TITLE
Fix for data race in heartBeatTimeChecker tests

### DIFF
--- a/cmd/nodeagent/main.go
+++ b/cmd/nodeagent/main.go
@@ -28,7 +28,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	n := NewNodeAgentManager(dynamicClient, nodeName, logEveryHeartbeat, ignoreHealthFromHeartbeat, time.Now)
+	n := NewNodeAgentManager(dynamicClient, nodeName, logEveryHeartbeat, ignoreHealthFromHeartbeat, time.Now, true)
 	log.Debug("Starting HTTP server")
 	http.HandleFunc("/v1/sessionHosts/", n.heartbeatHandler)
 	http.HandleFunc("/healthz", healthzHandler)

--- a/cmd/nodeagent/nodeagentmanager_test.go
+++ b/cmd/nodeagent/nodeagentmanager_test.go
@@ -617,6 +617,9 @@ var _ = Describe("nodeagent tests", func() {
 			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:00 PST")
 			return value
 		}
+
+		// in this test we run HeartbeatTimeChecker manually, so we turn off the loop that does it
+		// automatically to avoid them running at the same time
 		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow, false)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
@@ -659,6 +662,9 @@ var _ = Describe("nodeagent tests", func() {
 			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:00 PST")
 			return value
 		}
+
+		// in this test we run HeartbeatTimeChecker manually, so we turn off the loop that does it
+		// automatically to avoid them running at the same time
 		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow, false)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
@@ -727,6 +733,9 @@ var _ = Describe("nodeagent tests", func() {
 			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:00 PST")
 			return value
 		}
+
+		// in this test we run HeartbeatTimeChecker manually, so we turn off the loop that does it
+		// automatically to avoid them running at the same time
 		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow, false)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 

--- a/cmd/nodeagent/nodeagentmanager_test.go
+++ b/cmd/nodeagent/nodeagentmanager_test.go
@@ -41,7 +41,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("heartbeat with empty body should return error", func() {
 		req := httptest.NewRequest(http.MethodPost, "/v1/sessionHosts/sessionHostID", nil)
 		w := httptest.NewRecorder()
-		n := NewNodeAgentManager(newDynamicInterface(), testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(newDynamicInterface(), testNodeName, false, false, time.Now, true)
 		n.heartbeatHandler(w, req)
 		res := w.Result()
 		defer res.Body.Close()
@@ -54,7 +54,7 @@ var _ = Describe("nodeagent tests", func() {
 		b, _ := json.Marshal(hb)
 		req := httptest.NewRequest(http.MethodPost, "/v1/sessionHosts/sessionHostID", bytes.NewReader(b))
 		w := httptest.NewRecorder()
-		n := NewNodeAgentManager(newDynamicInterface(), testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(newDynamicInterface(), testNodeName, false, false, time.Now, true)
 		n.heartbeatHandler(w, req)
 		res := w.Result()
 		defer res.Body.Close()
@@ -72,7 +72,7 @@ var _ = Describe("nodeagent tests", func() {
 		w := httptest.NewRecorder()
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -99,7 +99,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should transition properly from standingBy to Active", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -177,7 +177,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should not create a GameServerDetail if the server is not Active", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -219,7 +219,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should delete the GameServer from the cache when it's deleted from Kubernetes", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -244,7 +244,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should create a GameServerDetail when the GameServer transitions to Active", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -290,7 +290,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should not create a GameServerDetail when an Unhealthy GameServer transitions to Active", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -337,7 +337,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should create a GameServerDetail on subsequent heartbeats, if it fails on the first time", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -454,7 +454,7 @@ var _ = Describe("nodeagent tests", func() {
 
 		var wg sync.WaitGroup
 		dynamicClient := newDynamicInterface()
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		for i := 0; i < 100; i++ {
 			wg.Add(1)
 			go func(randomGameServerName string) {
@@ -551,7 +551,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should set CreationTime value when registering a new game server", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -571,7 +571,7 @@ var _ = Describe("nodeagent tests", func() {
 	It("should set LastHeartbeatTime value when receiving a heartbeat from a game server", FlakeAttempts(numberOfAttemps), func() {
 		dynamicClient := newDynamicInterface()
 
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, time.Now, true)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		_, err := dynamicClient.Resource(gameserverGVR).Namespace(testGameServerNamespace).Create(context.Background(), gs, metav1.CreateOptions{})
@@ -617,7 +617,7 @@ var _ = Describe("nodeagent tests", func() {
 			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:00 PST")
 			return value
 		}
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow, false)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		// create the game server
@@ -659,7 +659,7 @@ var _ = Describe("nodeagent tests", func() {
 			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:00 PST")
 			return value
 		}
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow, false)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		// create the game server
@@ -727,7 +727,7 @@ var _ = Describe("nodeagent tests", func() {
 			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:00 PST")
 			return value
 		}
-		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow)
+		n := NewNodeAgentManager(dynamicClient, testNodeName, false, false, customNow, false)
 		gs := createUnstructuredTestGameServer(testGameServerName, testGameServerNamespace)
 
 		// create the game server
@@ -809,7 +809,7 @@ var _ = Describe("nodeagent tests", func() {
 		// change time to be 6 seconds later again
 		customNow = func() time.Time {
 			layout := "Mon, 02 Jan 2006 15:04:05 MST"
-			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:06 PST")
+			value, _ := time.Parse(layout, "Tue, 26 Apr 2022 10:00:12 PST")
 			return value
 		}
 		n.nowFunc = customNow


### PR DESCRIPTION
Fixes #325 
Added parameter to turn off the heartBeatTimeCheckerLoop, so you can run it manually without creating a data race.