### PR TITLE
fixing image tag for intelligent scaling

### DIFF
--- a/samples/server-load-simulator/simulator.yaml
+++ b/samples/server-load-simulator/simulator.yaml
@@ -17,7 +17,7 @@ spec:
       - args:
         - "-maxValue=100"
         - "-jitter=0.15"
-        image: ghcr.io/playfab/thundernetes-server-load-simulator:0.5
+        image: ghcr.io/playfab/thundernetes-server-load-simulator:0.5.0
         imagePullPolicy: IfNotPresent        
         name: simulator
         ports:

--- a/samples/standby-forecaster/forecaster.yaml
+++ b/samples/standby-forecaster/forecaster.yaml
@@ -36,7 +36,7 @@ spec:
       - args:
         - "-config-file=/data/config.yaml"
         - "-config-expand-env=true"
-        image: ghcr.io/playfab/thundernetes-standby-forecaster:0.5
+        image: ghcr.io/playfab/thundernetes-standby-forecaster:0.5.0
         imagePullPolicy: IfNotPresent        
         name: simulator
         ports:


### PR DESCRIPTION
This PR fixes the image tag for the standby forecaster and the simulator, as reported in #359 