### PR TITLE
remove init method from operator package

### DIFF
--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -17,6 +17,16 @@ This command will run the e2e tests locally, and it won't delete the cluster aft
 make clean deletekindcluster builddockerlocal createkindcluster e2elocal
 ```
 
+## Run the controller unit tests locally
+
+To tun the controller unit tests locally, you should go to the `pkg/operator` directory and run the following command:
+
+```bash
+make test
+```
+
+Make sure to not run them while kind cluster is up, since there will be port collisions and the tests will fail.
+
 ### Running end to end tests on macOS
 
 First of all, end to end tests require `envsubst` utility, assuming that you have Homebrew installed you can get it via `brew install gettext && brew link --force gettext`.

--- a/pkg/operator/controllers/controller_utils_test.go
+++ b/pkg/operator/controllers/controller_utils_test.go
@@ -150,11 +150,12 @@ var _ = Describe("Utilities tests", func() {
 					Name: "test-pod",
 				},
 			}
-			attachInitContainer(gs, pod, false)
+			var testInitContainerImage string = "testInitContainerImage"
+			attachInitContainer(gs, pod, testInitContainerImage, false)
 			Expect(pod.Spec.InitContainers[len(pod.Spec.InitContainers)-1]).To(BeEquivalentTo(corev1.Container{
 				Name:            InitContainerName,
 				ImagePullPolicy: corev1.PullIfNotPresent,
-				Image:           InitContainerImage,
+				Image:           testInitContainerImage,
 				Env:             getInitContainerEnvVariables(gs, false),
 				VolumeMounts: []corev1.VolumeMount{
 					{

--- a/pkg/operator/controllers/gameserver_controller.go
+++ b/pkg/operator/controllers/gameserver_controller.go
@@ -50,10 +50,12 @@ const finalizerName string = "gameservers.mps.playfab.com/finalizer"
 // GameServerReconciler reconciles a GameServer object
 type GameServerReconciler struct {
 	client.Client
-	Scheme                 *k8sruntime.Scheme
-	Recorder               record.EventRecorder
-	PortRegistry           *PortRegistry
-	GetNodeDetailsProvider func(ctx context.Context, r client.Reader, nodeName string) (string, string, int, error) // we abstract this for testing purposes
+	Scheme                  *k8sruntime.Scheme
+	Recorder                record.EventRecorder
+	PortRegistry            *PortRegistry
+	InitContainerImageLinux string
+	InitContainerImageWin   string
+	GetNodeDetailsProvider  func(ctx context.Context, r client.Reader, nodeName string) (string, string, int, error) // we abstract this for testing purposes
 }
 
 // we request secret RBAC access here so they can be potentially used by the allocation API service (for GameServer allocations)
@@ -145,8 +147,8 @@ func (r *GameServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if !podFoundInCache {
 		log.Info("Creating a new pod for GameServer", GameServerKind, gs.Name)
-
-		newPod := NewPodForGameServer(&gs)
+		log.Info("lala", "init1", r.InitContainerImageLinux, "init2", r.InitContainerImageWin)
+		newPod := NewPodForGameServer(&gs, r.InitContainerImageLinux, r.InitContainerImageWin)
 		if err := r.Create(ctx, newPod); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/operator/main.go
+++ b/pkg/operator/main.go
@@ -137,12 +137,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	initContainerImageLinux, initContainerImageWin := controllers.GetInitContainerImages(setupLog)
+
 	if err = (&controllers.GameServerReconciler{
-		Client:                 mgr.GetClient(),
-		Scheme:                 mgr.GetScheme(),
-		PortRegistry:           portRegistry,
-		Recorder:               mgr.GetEventRecorderFor("GameServer"),
-		GetNodeDetailsProvider: controllers.GetNodeDetails,
+		Client:                  mgr.GetClient(),
+		Scheme:                  mgr.GetScheme(),
+		PortRegistry:            portRegistry,
+		Recorder:                mgr.GetEventRecorderFor("GameServer"),
+		GetNodeDetailsProvider:  controllers.GetNodeDetails,
+		InitContainerImageLinux: initContainerImageLinux,
+		InitContainerImageWin:   initContainerImageWin,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GameServer")
 		os.Exit(1)


### PR DESCRIPTION
This PR removes the init() method from the operator package, resulting in better code.