### PR TITLE
portregistry returns multiple ports

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,4 +52,4 @@ jobs:
       - name: latency server server unit tests
         run: cd cmd/latencyserver && go test -race
       - name: operator unit tests
-        run: IMAGE_NAME_SAMPLE=thundernetes-netcore IMAGE_NAME_INIT_CONTAINER=thundernetes-initcontainer TAG=$(git rev-list HEAD --max-count=1 --abbrev-commit) make -C pkg/operator test
+        run: make -C pkg/operator test

--- a/pkg/operator/controllers/controller_utils.go
+++ b/pkg/operator/controllers/controller_utils.go
@@ -124,6 +124,7 @@ func NewGameServerForGameServerBuild(gsb *mpsv1alpha1.GameServerBuild, portRegis
 		// we don't create any status since we have the .Status subresource enabled
 	}
 	// get host ports
+	// we assume that each portToExpose exists only once in the GameServer spec
 	hostPorts, err := portRegistry.GetNewPorts(len(gsb.Spec.PortsToExpose))
 	j := 0
 	if err != nil {
@@ -139,7 +140,7 @@ func NewGameServerForGameServerBuild(gsb *mpsv1alpha1.GameServerBuild, portRegis
 				if gs.Spec.Template.Spec.HostNetwork {
 					container.Ports[i].ContainerPort = hostPorts[j]
 				}
-				j++
+				j++ // increase the hostPort index so on the next iteration (if any) we will use the next hostPort
 			}
 		}
 	}

--- a/pkg/operator/controllers/controller_utils.go
+++ b/pkg/operator/controllers/controller_utils.go
@@ -123,21 +123,23 @@ func NewGameServerForGameServerBuild(gsb *mpsv1alpha1.GameServerBuild, portRegis
 		},
 		// we don't create any status since we have the .Status subresource enabled
 	}
+	// get host ports
+	hostPorts, err := portRegistry.GetNewPorts(len(gsb.Spec.PortsToExpose))
+	j := 0
+	if err != nil {
+		return nil, err
+	}
 	// assigning host ports for all the containers in the Template.Spec
 	for i := 0; i < len(gs.Spec.Template.Spec.Containers); i++ {
 		container := gs.Spec.Template.Spec.Containers[i]
 		for i := 0; i < len(container.Ports); i++ {
 			if sliceContainsPortToExpose(gsb.Spec.PortsToExpose, container.Ports[i].ContainerPort) {
-				port, err := portRegistry.GetNewPort()
-				if err != nil {
-					return nil, err
-				}
-				container.Ports[i].HostPort = port
-
+				container.Ports[i].HostPort = hostPorts[j]
 				// if the user has specified that they want to use the host's network, we override the container port
 				if gs.Spec.Template.Spec.HostNetwork {
-					container.Ports[i].ContainerPort = port
+					container.Ports[i].ContainerPort = hostPorts[j]
 				}
+				j++
 			}
 		}
 	}

--- a/pkg/operator/controllers/gameserverbuild_controller_test.go
+++ b/pkg/operator/controllers/gameserverbuild_controller_test.go
@@ -2,16 +2,10 @@ package controllers
 
 import (
 	"context"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/playfab/thundernetes/pkg/operator/api/v1alpha1"
-)
-
-const (
-	assertPollingInterval = 20 * time.Millisecond
-	assertTimeout         = 2 * time.Second
 )
 
 var _ = Describe("GameServerBuild controller tests", func() {

--- a/pkg/operator/controllers/port_registry.go
+++ b/pkg/operator/controllers/port_registry.go
@@ -151,7 +151,7 @@ func (pr *PortRegistry) onNodeRemoved() {
 	pr.FreePortsCount -= int(pr.Max - pr.Min + 1)
 }
 
-// GetNewPorts returns and registers a slice of ports with lengh that will be used by a GameServer
+// GetNewPorts returns and registers a slice of ports with "count" length that will be used by a GameServer
 // It returns an error if there are no available ports
 // You may wonder what happens if two GameServer Pods get assigned the same HostPort
 // We will not have a collision, since Kubernetes is pretty smart and will place the Pod on a different Node, to prevent it

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,6 +34,11 @@ import (
 
 	mpsv1alpha1 "github.com/playfab/thundernetes/pkg/operator/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
+)
+
+const (
+	assertPollingInterval = 20 * time.Millisecond
+	assertTimeout         = 2 * time.Second
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to


### PR DESCRIPTION
This PR contains some prep work for #270. Specifically, it refactors portRegistry to be able to return multiple ports per GameServer.
We're gonna need one more PR where we actually remove the finalizer.