### PR TITLE
.NET Core sample - terminate after

### DIFF
--- a/samples/netcore/Program.cs
+++ b/samples/netcore/Program.cs
@@ -39,6 +39,13 @@ namespace netcore
                     Console.WriteLine($"Argument: {arg}");
                 } 
             }
+
+            string terminateSeconds = Environment.GetEnvironmentVariable("TERMINATE_AFTER_SECONDS");
+            if(Int32.TryParse(terminateSeconds, out int seconds) && seconds > 0)
+            {
+                Task.Run(async () => await TerminateAfterSeconds(seconds));
+            }
+
             CreateHostBuilder(args).Build().Run();
         }
 
@@ -66,6 +73,13 @@ namespace netcore
         {
             Utils.LogMessage($"Maintenance Scheduled at: {time}");
             _nextMaintenance = time;
+        }
+
+        static async Task TerminateAfterSeconds(int seconds)
+        {
+            Utils.LogMessage($"Terminating after {seconds} seconds");
+            await Task.Delay(TimeSpan.FromSeconds(seconds));
+            Environment.Exit(0);
         }
     }
 }


### PR DESCRIPTION
This PR adds an optional environmental variable on the .NET Core sample so that the fake game server will terminate after X seconds. This will help in creating a production simulation environment.