### PR TITLE
adding some jitter to timeout for netcore sample

### DIFF
--- a/samples/netcore/Program.cs
+++ b/samples/netcore/Program.cs
@@ -40,12 +40,6 @@ namespace netcore
                 } 
             }
 
-            string terminateSeconds = Environment.GetEnvironmentVariable("TERMINATE_AFTER_SECONDS");
-            if(Int32.TryParse(terminateSeconds, out int seconds) && seconds > 0)
-            {
-                Task.Run(async () => await TerminateAfterSeconds(seconds));
-            }
-
             CreateHostBuilder(args).Build().Run();
         }
 
@@ -73,13 +67,6 @@ namespace netcore
         {
             Utils.LogMessage($"Maintenance Scheduled at: {time}");
             _nextMaintenance = time;
-        }
-
-        static async Task TerminateAfterSeconds(int seconds)
-        {
-            Utils.LogMessage($"Terminating after {seconds} seconds");
-            await Task.Delay(TimeSpan.FromSeconds(seconds));
-            Environment.Exit(0);
         }
     }
 }

--- a/samples/netcore/Startup.cs
+++ b/samples/netcore/Startup.cs
@@ -79,7 +79,7 @@ namespace netcore
             string terminateSeconds = Environment.GetEnvironmentVariable("TERMINATE_AFTER_SECONDS");
             if(Int32.TryParse(terminateSeconds, out int seconds) && seconds > 0)
             {
-                Task.Run(async () => await TerminateAfterSeconds(seconds));
+                await Task.Run(async () => await TerminateAfterSeconds(seconds));
             }
         }
 
@@ -96,7 +96,8 @@ namespace netcore
 
         private static async Task TerminateAfterSeconds(int seconds)
         {
-            int timeout = new Random().Next(-60,60) + seconds;
+            // will exit after [20,2*TERMINATE_AFTER_SECONDS] seconds
+            int timeout = new Random().Next(20, 2*seconds);
             Utils.LogMessage($"Terminating after {timeout} seconds");
             await Task.Delay(TimeSpan.FromSeconds(timeout));
             Environment.Exit(0);

--- a/samples/netcore/Startup.cs
+++ b/samples/netcore/Startup.cs
@@ -75,6 +75,12 @@ namespace netcore
                 new ConnectedPlayer("Ken"),
                 new ConnectedPlayer("Dimitris")
             });
+
+            string terminateSeconds = Environment.GetEnvironmentVariable("TERMINATE_AFTER_SECONDS");
+            if(Int32.TryParse(terminateSeconds, out int seconds) && seconds > 0)
+            {
+                Task.Run(async () => await TerminateAfterSeconds(seconds));
+            }
         }
 
         private static void PrintGSDKInfo()
@@ -86,8 +92,15 @@ namespace netcore
                 Console.WriteLine($"    Config with key {item.Key} has value {item.Value}");
             }
             Console.WriteLine("End - printing config settings");
-
         }        
+
+        private static async Task TerminateAfterSeconds(int seconds)
+        {
+            int timeout = new Random().Next(-60,60) + seconds;
+            Utils.LogMessage($"Terminating after {timeout} seconds");
+            await Task.Delay(TimeSpan.FromSeconds(timeout));
+            Environment.Exit(0);
+        }
     }
 
     public static class Utils


### PR DESCRIPTION
This PR makes the netcore sample terminate only after it has transitioned to Active and it also adds some jitter to the timeout.