### PR TITLE
Changed Kustomize version to latest to get rid of Test errors on Mac …

### DIFF
--- a/pkg/operator/.gitignore
+++ b/pkg/operator/.gitignore
@@ -7,6 +7,9 @@
 *.dylib
 bin
 
+# testbin for MacOS
+testbin
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/pkg/operator/Makefile
+++ b/pkg/operator/Makefile
@@ -133,7 +133,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
+KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.9.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"


### PR DESCRIPTION
Fixed an error for Mac OS with M1. Therefor I changed the version of Kustomize to the newest (4.5.7)