### PR TITLE
reduce error reporting in GameServer controller

### DIFF
--- a/pkg/operator/controllers/gameserver_controller.go
+++ b/pkg/operator/controllers/gameserver_controller.go
@@ -155,7 +155,10 @@ func (r *GameServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			// updating GameServer with the new state
 			if err := r.Status().Patch(ctx, &gs, patch); err != nil {
-				return ctrl.Result{}, err
+				// return error only if it is "NotFound"
+				if !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
 			}
 			return ctrl.Result{}, nil
 		}

--- a/pkg/operator/controllers/gameserver_controller.go
+++ b/pkg/operator/controllers/gameserver_controller.go
@@ -155,7 +155,8 @@ func (r *GameServerReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			}
 			// updating GameServer with the new state
 			if err := r.Status().Patch(ctx, &gs, patch); err != nil {
-				// return error only if it is "NotFound"
+				// there is a chance that we have arrived here while the GameServer has been deleted
+				// in this case, .Patch will fail with NotFound error and we can safely ignore it
 				if !apierrors.IsNotFound(err) {
 					return ctrl.Result{}, err
 				}


### PR DESCRIPTION
During a test, we discovered that a lot of errors are generated in the GameServer controller when we try to update the GameServer CR when the Pod has died. This might happen because the GameServer CR has died, so there is no point in updating it. Consequently, we update the error condition to report the error only when the error is not "NotFound". 