### PR TITLE
Uplugin allocator plugin syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ installfilesdev
 .uptodate
 
 # allocator compiled plugin
-kubectl-gameserver-allocate
+kubectl-gameserver

--- a/cmd/allocator/build-plugin.sh
+++ b/cmd/allocator/build-plugin.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-CURR_PATH="$(dirname "$BASH_SOURCE")"
+CURR_PATH="$(cd "$(dirname "$BASH_SOURCE")"; pwd)"
 go build -o $CURR_PATH $CURR_PATH/main.go
-mv $CURR_PATH/command-line-arguments $CURR_PATH/kubectl-gameserver-allocate
-export PATH=$PATH:"$(cd $CURR_PATH; pwd)"
+mv $CURR_PATH/command-line-arguments $CURR_PATH/kubectl-gameserver
+BASH_RC="$(cat ~/.bashrc)"
+if ! [[ $BASH_RC =~ "$CURR_PATH" ]]; then
+  echo "export PATH=\"\$PATH:"$CURR_PATH"\"" >> ~/.bashrc
+fi
 kubectl plugin list


### PR DESCRIPTION
Fixed so you didn't have to specify `allocator` twice when using. now `kubectl gameserver` will show the help text and `kubectl gameserver allocate/list` will work as expected. also updated the `~/.bashrc` to more reliably update the `$PATH` variable.