### PR TITLE
fixing unit test

### DIFF
--- a/pkg/operator/controllers/port_registry_test.go
+++ b/pkg/operator/controllers/port_registry_test.go
@@ -430,7 +430,13 @@ var _ = Describe("Random port registration on port registry with two thousand po
 				defer wg.Done()
 				n := rand.Intn(200) + 50 // n will be between 50 and 250
 				time.Sleep(time.Duration(n) * time.Millisecond)
-				gameServerName := generateName(prefix)
+				var gameServerName string
+				for { // make sure we don't register the same GameServer twice
+					gameServerName = generateName(prefix)
+					if _, ok := gameServerNamesAndPorts.Load(gameServerName); !ok {
+						break
+					}
+				}
 				ports, err := portRegistry.GetNewPorts(testnamespace, gameServerName, 1)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(ports)).To(Equal(1))


### PR DESCRIPTION
Sometimes, a PortRegistry unit test that generates two thousand game servers encounters some name collisions and fails, example https://github.com/PlayFab/thundernetes/actions/runs/3098943446

This PR validates that the GameServer names are unique.