### PR TITLE
Draft - update networking between nodeagent daemonset and gameserver pods

### DIFF
--- a/installfiles/operator_with_monitoring.yaml
+++ b/installfiles/operator_with_monitoring.yaml
@@ -8997,7 +8997,6 @@ metadata:
   name: thundernetes-gameserver-health-service
   namespace: thundernetes-system
 spec:
-  clusterIP: None # Headless service to get nodeagent pod IP directly
   selector:
     name: nodeagent
   ports:

--- a/installfiles/operator_with_monitoring.yaml
+++ b/installfiles/operator_with_monitoring.yaml
@@ -8970,6 +8970,42 @@ spec:
           defaultMode: 420
           secretName: webhook-server-cert
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: thundernetes-nodeagent-network-policy
+  namespace: thundernetes-system
+spec:
+  podSelector:
+    matchLabels:
+      name: nodeagent
+  policyTypes:
+    - Ingress
+  ingress: 
+    - from:
+      - podSelector: # matches all pods with this label in any namespace
+          matchLabels:
+            OwningOperator: thundernetes
+        namespaceSelector: {}
+      - namespaceSelector: # matches all pods in the monitoring namespace
+          matchLabels:
+            kubernetes.io/metadata.name: monitoring
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: thundernetes-gameserver-health-service
+  namespace: thundernetes-system
+spec:
+  clusterIP: None # Headless service to get nodeagent pod IP directly
+  selector:
+    name: nodeagent
+  ports:
+    - protocol: TCP
+      port: 56001
+      targetPort: 56001
+  internalTrafficPolicy: Local # Routes traffic to pods only on the same node
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -8995,7 +9031,9 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: LOG_LEVEL
-          value: info
+          value: debug
+        - name: LOG_EVERY_HEARTBEAT
+          value: "true"
         image: ghcr.io/playfab/thundernetes-nodeagent:0.5.0
         livenessProbe:
           httpGet:
@@ -9006,7 +9044,7 @@ spec:
         name: nodeagent
         ports:
         - containerPort: 56001
-          hostPort: 56001
+          hostPort: 56001 # this isn't needed anymore since the gameservers will have a service name instead of an IP
           name: nodeagentport
         resources:
           limits:


### PR DESCRIPTION
thought a lot about #108 and this is what i have so far:

- adding a network policy for the nodeagent pods allows you to control the ingress/egress traffic. there isn't a lot to it, it only lets you choose on label names for pods/namespaces/cidr blocks. the following network policy only allows traffic from any pod with the `OwningOperator: thundernetes` in any namespace, and from pods in the `monitoring` namespace. this would still allow traffic from pods in other nodes, but that is addressed below

- adding a ~headless~ service in front of the nodeagent pods allows the gameservers to reach the heartbeat endpoint via a FQDN rather than the node ip address. the service also has `internalTrafficPolicy: Local`, meaning gameservers will always be routed to nodeagent pods on the same node. i think this is a more decoupled strategy rather than using the node ip. 

edit: dont think it needs to be a headless service actually, we dont want DNS records returned for each node behind the service, we just want the service to route to the correct node. [more info about that here](https://kubernetes.io/docs/concepts/services-networking/service/#internal-traffic-policy).

- using DNS to get a public IP address of the current node could (in theory) solve the problem of getting the node public IP in the gameserver pods, although i have not figured out how to do that. doing an `nslookup` of the node name resolves to the internal IP.

let me know what you think. I see that the setup for the game server pod creation is opinionated by using the init container to create a json file for the gsdk, so I wasn't sure at what point during the initialization was best to inject the service endpoint variable in the environment.

