### PR TITLE
Update debugging.md

### DIFF
--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -13,6 +13,8 @@ To test your local code you have 2 options: you can run the code in a local kind
 
 First of all, you need to install `kustomize`. You can do it by running `make -C pkg/operator kustomize`.
 
+Next, you need to install `kind`. You can do this by running `make installkind` in the main project folder
+
 This command will run the e2e tests locally, and it won't delete the cluster after it's done, so you can either deploy more GameServerBuilds or check the ones used for the tests under the `e2e` namespace.
 
 {% include code-block-start.md %}


### PR DESCRIPTION
deletekindcluster and createkindcluster both rely on a local pkg/operator/testbin/bin/kind which is built from the installkind step. Having kind installed in /usr/local/bin results in a file not found when running the e2e test sample