### PR TITLE
Minecraft Sample docs

### DIFF
--- a/docs/quickstart/sample-minecraft.md
+++ b/docs/quickstart/sample-minecraft.md
@@ -14,6 +14,6 @@ This sample, located [here](https://github.com/PlayFab/thundernetes/tree/main/sa
 kubectl apply -f https://raw.githubusercontent.com/PlayFab/thundernetes/main/samples/minecraft/sample.yaml
 {% include code-block-end.md %}
 
-To connect to an active server, you need to own a Minecraft Bedrock Edition copy (paid) from [here](https://www.minecraft.net/en-us/get-minecraft).
+To connect to an active server, you need to own a Minecraft Java Edition copy (paid) from [here](https://www.minecraft.net/en-us/get-minecraft).
 
 To allocate a game server (convert its state to active) and scale your GameServerBuild, you can check [here](allocation-scaling.md).

--- a/docs/quickstart/sample-minecraft.md
+++ b/docs/quickstart/sample-minecraft.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: Minecraft sample
+parent: Samples
+grand_parent: Quickstart
+nav_order: 2
+---
+
+# Minecraft sample
+
+This sample, located [here](https://github.com/PlayFab/thundernetes/tree/main/samples/minecraft), is based on the popular sandbox game [Minecraft](https://www.minecraft.net/). You can install it using this script:
+
+{% include code-block-start.md %}
+kubectl apply -f https://raw.githubusercontent.com/PlayFab/thundernetes/main/samples/minecraft/sample.yaml
+{% include code-block-end.md %}
+
+To connect to an active server, you need to own a Minecraft Bedrock Edition copy (paid) from [here](https://www.minecraft.net/en-us/get-minecraft).
+
+To allocate a game server (convert its state to active) and scale your GameServerBuild, you can check [here](allocation-scaling.md).

--- a/docs/quickstart/sample-minecraft.md
+++ b/docs/quickstart/sample-minecraft.md
@@ -3,7 +3,7 @@ layout: default
 title: Minecraft sample
 parent: Samples
 grand_parent: Quickstart
-nav_order: 2
+nav_order: 3
 ---
 
 # Minecraft sample

--- a/samples/minecraft/README.md
+++ b/samples/minecraft/README.md
@@ -1,0 +1,5 @@
+# Minecraft GSDK sample for thundernetes
+
+Check the [quickstart](https://github.com/PlayFab/thundernetes/blob/main/docs/quickstart.md) on how to run the Minecraft sample on thundernetes.
+
+This image is based on the itzg/minecraft-server docker image, but modified to initiate the server with the GSDK wrapper, since Minecraft is not an OSS. The modified dockerfile can be found [here](https://github.com/rnjohn/docker-minecraft-server-gsdk).

--- a/samples/minecraft/README.md
+++ b/samples/minecraft/README.md
@@ -1,6 +1,6 @@
-# Minecraft GSDK sample for thundernetes
+# Minecraft GSDK sample for Thundernetes
 
-Check the [quickstart](https://github.com/PlayFab/thundernetes/blob/main/docs/quickstart.md) on how to run the Minecraft sample on thundernetes.
+Check the [quickstart](https://github.com/PlayFab/thundernetes/blob/main/docs/quickstart.md) on how to run the Minecraft sample on Thundernetes.
 
 This image is based on the itzg/minecraft-server [docker image](https://hub.docker.com/r/itzg/minecraft-server), which provides a Minecraft Server that will automatically download the latest stable version at startup. And it can also run/upgrade to any specific version or the latest snapshot. What I did was to modify the Dockerfile to retrieve the built GSDK wrapper from the GSDK wrapper docker image and copy it into the MC one, and then execute the wrapper along the script to start the server. The modified dockerfile can be found [here](https://github.com/rnjohn/docker-minecraft-server-gsdk).
 

--- a/samples/minecraft/README.md
+++ b/samples/minecraft/README.md
@@ -2,4 +2,6 @@
 
 Check the [quickstart](https://github.com/PlayFab/thundernetes/blob/main/docs/quickstart.md) on how to run the Minecraft sample on thundernetes.
 
-This image is based on the itzg/minecraft-server docker image, but modified to initiate the server with the GSDK wrapper, since Minecraft is not an OSS. The modified dockerfile can be found [here](https://github.com/rnjohn/docker-minecraft-server-gsdk).
+This image is based on the itzg/minecraft-server [docker image](https://hub.docker.com/r/itzg/minecraft-server), which provides a Minecraft Server that will automatically download the latest stable version at startup. And it can also run/upgrade to any specific version or the latest snapshot. What I did was to modify the Dockerfile to retrieve the built GSDK wrapper from the GSDK wrapper docker image and copy it into the MC one, and then execute the wrapper along the script to start the server. The modified dockerfile can be found [here](https://github.com/rnjohn/docker-minecraft-server-gsdk).
+
+According to [itzg](https://github.com/itzg), the container will download the latest version of the "vanilla" Minecraft: Java Edition server provided by Mojang. The VERSION and the TYPE can be configured to create many variations of desired Minecraft server. In the itzg original [GitHub repo](https://github.com/itzg/docker-minecraft-server) you can find much more info in how does the container work and how to add more options on top of it, like plugins and mods.

--- a/samples/minecraft/sample.yaml
+++ b/samples/minecraft/sample.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     spec:
       containers:
-        - image: rnjohn/minecraft-server-test
+        - image: rnjohn/minecraft-server-test:latest
           name: thundernetes-sample-minecraft
           ports:
           - containerPort: 25565 # your game server port

--- a/samples/minecraft/sample.yaml
+++ b/samples/minecraft/sample.yaml
@@ -1,0 +1,24 @@
+apiVersion: mps.playfab.com/v1alpha1
+kind: GameServerBuild
+metadata:
+  name: gameserverbuild-sample-minecraft
+spec:
+  titleID: "1E03" # required
+  buildID: "85ffe8da-c82f-4035-86c5-9d2b5f42d6f8" # must be a GUID
+  standingBy: 2 # required
+  max: 4 # required
+  crashesToMarkUnhealthy: 5 # optional, default is 5. It is the number of crashes needed to mark the build unhealthy
+  portsToExpose:
+    - 25565
+  template:
+    spec:
+      containers:
+        - image: rnjohn/minecraft-server-test
+          name: thundernetes-sample-minecraft
+          ports:
+          - containerPort: 25565 # your game server port
+            protocol: TCP # your game server port protocol
+            name: gameport # required field
+          env:
+            - name: EULA
+              value: "true"


### PR DESCRIPTION
This PR aims to add a documentation to start a Minecraft Java Edition server using Thundernetes. A sample.yaml file was created to be applied to the kubernetes cluster and also there is instructions on how to do so.