### PR TITLE
Parameterize # of GameServer Creation/Deletion

### DIFF
--- a/pkg/operator/config/manager/manager.yaml
+++ b/pkg/operator/config/manager/manager.yaml
@@ -46,10 +46,6 @@ spec:
               value: ${API_SERVICE_SECURITY}
             - name: ALLOC_API_SVC_PORT
               value: "5000"
-            - name: MAX_NUM_GS_TO_ADD
-              value: "20"
-            - name: MAX_NUM_GS_TO_DEL
-              value: "20"
             - name: THUNDERNETES_INIT_CONTAINER_IMAGE
               value: ${IMAGE_NAME_INIT_CONTAINER}:${IMAGE_TAG}
             - name: THUNDERNETES_INIT_CONTAINER_IMAGE_WIN

--- a/pkg/operator/config/manager/manager.yaml
+++ b/pkg/operator/config/manager/manager.yaml
@@ -46,6 +46,10 @@ spec:
               value: ${API_SERVICE_SECURITY}
             - name: ALLOC_API_SVC_PORT
               value: "5000"
+            - name: MAX_NUM_GS_TO_ADD
+              value: "20"
+            - name: MAX_NUM_GS_TO_DEL
+              value: "20"
             - name: THUNDERNETES_INIT_CONTAINER_IMAGE
               value: ${IMAGE_NAME_INIT_CONTAINER}:${IMAGE_TAG}
             - name: THUNDERNETES_INIT_CONTAINER_IMAGE_WIN

--- a/pkg/operator/controllers/config.go
+++ b/pkg/operator/controllers/config.go
@@ -1,0 +1,20 @@
+package controllers
+
+// Config is a struct containing configuration from environment variables
+// source: https://github.com/caarlos0/env
+type Config struct {
+	ApiServiceSecurity                     string `env:"API_SERVICE_SECURITY"`
+	TlsSecretName                          string `env:"TLS_SECRET_NAME" envDefault:"tls-secret"`
+	TlsSecretNamespace                     string `env:"TLS_SECRET_NAMESPACE" envDefault:"thundernetes-system"`
+	TlsCertificateName                     string `env:"TLS_CERTIFICATE_FILENAME" envDefault:"tls.crt"`
+	TlsPrivateKeyFilename                  string `env:"TLS_PRIVATE_KEY_FILENAME" envDefault:"tls.key"`
+	PortRegistryExclusivelyGameServerNodes bool   `env:"PORT_REGISTRY_EXCLUSIVELY_GAME_SERVER_NODES" envDefault:"false"`
+	LogLevel                               string `env:"LOG_LEVEL" envDefault:"info"`
+	MinPort                                int32  `env:"MIN_PORT" envDefault:"10000"`
+	MaxPort                                int32  `env:"MAX_PORT" envDefault:"12000"`
+	AllocationApiSvcPort                   int32  `env:"ALLOC_API_SVC_PORT" envDefault:"5000"`
+	InitContainerImageLinux                string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE,notEmpty"`
+	InitContainerImageWin                  string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE_WIN,notEmpty"`
+	MaxNumberOfGameServersToAdd            int  `env:"MAX_NUM_GS_TO_ADD" envDefault:"20"`
+	MaxNumberOfGameServersToDelete         int  `env:"MAX_NUM_GS_TO_DEL" envDefault:"20"`
+}

--- a/pkg/operator/controllers/config.go
+++ b/pkg/operator/controllers/config.go
@@ -15,6 +15,6 @@ type Config struct {
 	AllocationApiSvcPort                   int32  `env:"ALLOC_API_SVC_PORT" envDefault:"5000"`
 	InitContainerImageLinux                string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE,notEmpty"`
 	InitContainerImageWin                  string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE_WIN,notEmpty"`
-	MaxNumberOfGameServersToAdd            int  `env:"MAX_NUM_GS_TO_ADD" envDefault:"20"`
-	MaxNumberOfGameServersToDelete         int  `env:"MAX_NUM_GS_TO_DEL" envDefault:"20"`
+	MaxNumberOfGameServersToAdd            int    `env:"MAX_NUM_GS_TO_ADD" envDefault:"20"`
+	MaxNumberOfGameServersToDelete         int    `env:"MAX_NUM_GS_TO_DEL" envDefault:"20"`
 }

--- a/pkg/operator/controllers/config.go
+++ b/pkg/operator/controllers/config.go
@@ -3,7 +3,7 @@ package controllers
 // Config is a struct containing configuration from environment variables
 // source: https://github.com/caarlos0/env
 type Config struct {
-	ApiServiceSecurity                     string `env:"API_SERVICE_SECURITY"`
+	ApiServiceSecurity                     string `env:"API_SERVICE_SECURITY" envDefault:"none"`
 	TlsSecretName                          string `env:"TLS_SECRET_NAME" envDefault:"tls-secret"`
 	TlsSecretNamespace                     string `env:"TLS_SECRET_NAMESPACE" envDefault:"thundernetes-system"`
 	TlsCertificateName                     string `env:"TLS_CERTIFICATE_FILENAME" envDefault:"tls.crt"`
@@ -13,8 +13,8 @@ type Config struct {
 	MinPort                                int32  `env:"MIN_PORT" envDefault:"10000"`
 	MaxPort                                int32  `env:"MAX_PORT" envDefault:"12000"`
 	AllocationApiSvcPort                   int32  `env:"ALLOC_API_SVC_PORT" envDefault:"5000"`
-	InitContainerImageLinux                string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE,notEmpty"`
-	InitContainerImageWin                  string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE_WIN,notEmpty"`
+	InitContainerImageLinux                string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE,notEmpty" envDefault:"ghcr.io/playfab/thundernetes-initcontainer:0.6.0"`
+	InitContainerImageWin                  string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE_WIN,notEmpty" envDefault:"ghcr.io/playfab/thundernetes-initcontainer-win:0.6.0"`
 	MaxNumberOfGameServersToAdd            int    `env:"MAX_NUM_GS_TO_ADD" envDefault:"20"`
 	MaxNumberOfGameServersToDelete         int    `env:"MAX_NUM_GS_TO_DEL" envDefault:"20"`
 }

--- a/pkg/operator/controllers/gameserverbuild_controller.go
+++ b/pkg/operator/controllers/gameserverbuild_controller.go
@@ -43,14 +43,6 @@ import (
 // value is the number of crashes
 var crashesPerBuild = sync.Map{}
 
-const (
-	// maximum number of GameServers to create per reconcile loop
-	// we have this in place since each create call is synchronous and we want to minimize the time for each reconcile loop
-	maxNumberOfGameServersToAdd = 20
-	// maximum number of GameServers to delete per reconcile loop
-	maxNumberOfGameServersToDelete = 20
-)
-
 // Simple async map implementation using a mutex
 // used to manage the expected GameServer creations and deletions
 type MutexMap struct {
@@ -65,17 +57,24 @@ type GameServerBuildReconciler struct {
 	PortRegistry *PortRegistry
 	Recorder     record.EventRecorder
 	expectations *GameServerExpectations
+	//maximum number of GameServers to add per reconcile loop
+	// we have this in place since each create call is synchronous and we want to minimize the time for each reconcile loop
+	maxNumberOfGameServersToAdd int
+	//maximum number of GameServers to delete per reconcile loop
+	maxNumberOfGameServersToDelete int
 }
 
 // NewGameServerBuildReconciler returns a pointer to a new GameServerBuildReconciler
-func NewGameServerBuildReconciler(mgr manager.Manager, portRegistry *PortRegistry) *GameServerBuildReconciler {
+func NewGameServerBuildReconciler(mgr manager.Manager, portRegistry *PortRegistry, maxGsToAdd, maxGsToDelete int) *GameServerBuildReconciler {
 	cl := mgr.GetClient()
 	return &GameServerBuildReconciler{
-		Client:       cl,
-		Scheme:       mgr.GetScheme(),
-		PortRegistry: portRegistry,
-		Recorder:     mgr.GetEventRecorderFor("GameServerBuild"),
-		expectations: NewGameServerExpectations(cl),
+		Client:                         cl,
+		Scheme:                         mgr.GetScheme(),
+		PortRegistry:                   portRegistry,
+		Recorder:                       mgr.GetEventRecorderFor("GameServerBuild"),
+		expectations:                   NewGameServerExpectations(cl),
+		maxNumberOfGameServersToAdd:    maxGsToAdd,
+		maxNumberOfGameServersToDelete: maxGsToDelete,
 	}
 }
 
@@ -187,12 +186,12 @@ func (r *GameServerBuildReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	var totalNumberOfGameServersToDelete int = 0
 	// user has decreased standingBy numbers
 	if nonActiveGameServersCount > gsb.Spec.StandingBy {
-		totalNumberOfGameServersToDelete += int(math.Min(float64(nonActiveGameServersCount-gsb.Spec.StandingBy), maxNumberOfGameServersToDelete))
+		totalNumberOfGameServersToDelete += int(math.Min(float64(nonActiveGameServersCount-gsb.Spec.StandingBy), float64(r.maxNumberOfGameServersToDelete)))
 	}
 	// we also need to check if we are above the max
 	// this can happen if the user modifies the spec.Max during the GameServerBuild's lifetime
 	if nonActiveGameServersCount+activeCount > gsb.Spec.Max {
-		totalNumberOfGameServersToDelete += int(math.Min(float64(totalNumberOfGameServersToDelete+(nonActiveGameServersCount+activeCount-gsb.Spec.Max)), maxNumberOfGameServersToDelete))
+		totalNumberOfGameServersToDelete += int(math.Min(float64(totalNumberOfGameServersToDelete+(nonActiveGameServersCount+activeCount-gsb.Spec.Max)), float64(r.maxNumberOfGameServersToDelete)))
 	}
 	if totalNumberOfGameServersToDelete > 0 {
 		err := r.deleteNonActiveGameServers(ctx, &gsb, &gameServers, totalNumberOfGameServersToDelete)
@@ -205,12 +204,12 @@ func (r *GameServerBuildReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// we're also limiting the number of game servers that are created to avoid issues like this https://github.com/kubernetes-sigs/controller-runtime/issues/1782
 	// we attempt to create the missing number of game servers, but we don't want to create more than the max
 	// an error channel for the go routines to write errors
-	errCh := make(chan error, maxNumberOfGameServersToAdd)
+	errCh := make(chan error, r.maxNumberOfGameServersToAdd)
 	// a waitgroup for async create calls
 	var wg sync.WaitGroup
 	for i := 0; i < gsb.Spec.StandingBy-nonActiveGameServersCount &&
 		i+nonActiveGameServersCount+activeCount < gsb.Spec.Max &&
-		i < maxNumberOfGameServersToAdd; i++ {
+		i < r.maxNumberOfGameServersToAdd; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caarlos0/env/v6"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -37,11 +38,9 @@ import (
 )
 
 const (
-	assertPollingInterval          = 20 * time.Millisecond
-	assertTimeout                  = 2 * time.Second
-	allocationApiSvcPort           = 5000
-	maxNumberOfGameServersToAdd    = 20
-	maxNumberOfGameServersToDelete = 20
+	assertPollingInterval = 20 * time.Millisecond
+	assertTimeout         = 2 * time.Second
+	allocationApiSvcPort  = 5000
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -77,10 +76,10 @@ var _ = BeforeSuite(func() {
 	//If config is passed to a constructor, whatever fields constructor uses need to be defined explicitly
 	//This does not pull values from operator.yaml like it does in main.go
 	//For suite_test the env defaults should be used, defined in const above
-	config := &Config{
-		MaxNumberOfGameServersToAdd:    maxNumberOfGameServersToAdd,
-		MaxNumberOfGameServersToDelete: maxNumberOfGameServersToDelete,
-	}
+	config := &Config{}
+	err := env.Parse(config)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(config).NotTo(BeNil())
 
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -74,6 +74,8 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
+	config := &Config{}
+
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
@@ -100,7 +102,7 @@ var _ = BeforeSuite(func() {
 	err = portRegistry.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (NewGameServerBuildReconciler(k8sManager, portRegistry, maxNumberOfGameServersToAdd, maxNumberOfGameServersToDelete)).SetupWithManager(k8sManager)
+	err = (NewGameServerBuildReconciler(k8sManager, portRegistry, config)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	initContainerImageLinux, initContainerImageWin := "testImageLinux", "testImageWin"

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -74,7 +74,12 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	config := &Config{}
+	//If config is passed to a constructor, whatever fields constructor uses need to be defined explicitly
+	//This does not pull values from operator.yaml like it does in main.go
+	config := &Config{
+		MaxNumberOfGameServersToAdd:    20,
+		MaxNumberOfGameServersToDelete: 20,
+	}
 
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -76,6 +76,7 @@ var _ = BeforeSuite(func() {
 
 	//If config is passed to a constructor, whatever fields constructor uses need to be defined explicitly
 	//This does not pull values from operator.yaml like it does in main.go
+	//For suite_test the env defaults should be used
 	config := &Config{
 		MaxNumberOfGameServersToAdd:    20,
 		MaxNumberOfGameServersToDelete: 20,

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -37,9 +37,11 @@ import (
 )
 
 const (
-	assertPollingInterval = 20 * time.Millisecond
-	assertTimeout         = 2 * time.Second
-	allocationApiSvcPort  = 5000
+	assertPollingInterval          = 20 * time.Millisecond
+	assertTimeout                  = 2 * time.Second
+	allocationApiSvcPort           = 5000
+	maxNumberOfGameServersToAdd    = 20
+	maxNumberOfGameServersToDelete = 20
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -98,7 +100,7 @@ var _ = BeforeSuite(func() {
 	err = portRegistry.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = (NewGameServerBuildReconciler(k8sManager, portRegistry)).SetupWithManager(k8sManager)
+	err = (NewGameServerBuildReconciler(k8sManager, portRegistry, maxNumberOfGameServersToAdd, maxNumberOfGameServersToDelete)).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	initContainerImageLinux, initContainerImageWin := "testImageLinux", "testImageWin"

--- a/pkg/operator/controllers/suite_test.go
+++ b/pkg/operator/controllers/suite_test.go
@@ -76,10 +76,10 @@ var _ = BeforeSuite(func() {
 
 	//If config is passed to a constructor, whatever fields constructor uses need to be defined explicitly
 	//This does not pull values from operator.yaml like it does in main.go
-	//For suite_test the env defaults should be used
+	//For suite_test the env defaults should be used, defined in const above
 	config := &Config{
-		MaxNumberOfGameServersToAdd:    20,
-		MaxNumberOfGameServersToDelete: 20,
+		MaxNumberOfGameServersToAdd:    maxNumberOfGameServersToAdd,
+		MaxNumberOfGameServersToDelete: maxNumberOfGameServersToDelete,
 	}
 
 	cfg, err := testEnv.Start()

--- a/pkg/operator/main.go
+++ b/pkg/operator/main.go
@@ -63,6 +63,8 @@ type Config struct {
 	AllocationApiSvcPort                   int32  `env:"ALLOC_API_SVC_PORT" envDefault:"5000"`
 	InitContainerImageLinux                string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE,notEmpty"`
 	InitContainerImageWin                  string `env:"THUNDERNETES_INIT_CONTAINER_IMAGE_WIN,notEmpty"`
+	MaxNumberOfGameServersToAdd            int32  `env:"MAX_NUM_GS_TO_ADD" envDefault:"20"`
+	MaxNumberOfGameServersToDelete         int32  `env:"MAX_NUM_GS_TO_DEL" envDefault:"20"`
 }
 
 var (
@@ -151,7 +153,7 @@ func main() {
 	}
 
 	// initialize the GameServerBuild controller
-	if err = controllers.NewGameServerBuildReconciler(mgr, portRegistry).SetupWithManager(mgr); err != nil {
+	if err = controllers.NewGameServerBuildReconciler(mgr, portRegistry, int(cfg.MaxNumberOfGameServersToAdd), int(cfg.MaxNumberOfGameServersToDelete)).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "GameServerBuild")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Fixes #157 

Felt like a pretty similar change to #419, so I figured I would take a look. 

- The max number of servers to add/delete are now parameters in gameserverbuild_controller.go
- config.go was created, moving the config struct from main.go to its own file inside controllers
- This allows any controller to now accept the config struct and make use of env variables
- gameserverbuild_controller.go constructor now utilizes the config
- Changing the default values of 20 can be done during deployments via env variables

I did not make these env variables in the makefile. I could refactor the PR to do so if desired, but I figured it would be better to wait on a change fixing the dropped double quotes I faced in #419 . Unlike that one, these wouldn't require an int and string variable so it would be a little prettier. Combining these max add/delete into one variable may also be a refactor to consider. Thanks!
